### PR TITLE
AmericanToBritish: fixed WordList entry

### DIFF
--- a/AmericanToBritish/DLL/WordList.xml
+++ b/AmericanToBritish/DLL/WordList.xml
@@ -90,7 +90,7 @@
   <Word us="popularize " br="popularise " />
   <Word us="postman" br="mailman" />
   <Word us="practice " br="practise " />
-  <Word us="practicing " br="practising" />
+  <Word us="practicing " br="practising " />
   <Word us="pretense" br="pretence" />
   <Word us="program" br="programme" />
   <Word us="pulled up" br="drew up" />


### PR DESCRIPTION
When this entry is applied it will erroneously remove a space character.