### PR TITLE
AmericanToBritish: removed invalid WordList entry

### DIFF
--- a/AmericanToBritish/DLL/WordList.xml
+++ b/AmericanToBritish/DLL/WordList.xml
@@ -13,7 +13,6 @@
   <Word us="appetizer" br="appetiser" />
   <Word us="apprize" br="apprise" />
   <Word us="archeology" br="archaeology" />
-  <Word us="argument" br="arguement" />
   <Word us="armor" br="armour" />
   <Word us="behavior" br="behaviour" />
   <Word us="caliber" br="calibre" />


### PR DESCRIPTION
In the Queen's English the correct spelling is **argument**.
See [Oxford Dictionairies.](https://www.oxforddictionaries.com/spellcheck/english/?q=arguement)