### PR TITLE
AmericanToBritish: local word list can extend embedded list

### DIFF
--- a/AmericanToBritish/DLL/IPlugin.cs
+++ b/AmericanToBritish/DLL/IPlugin.cs
@@ -15,12 +15,12 @@ namespace Nikse.SubtitleEdit.PluginLogic
         string Text { get; }
 
         /// <summary>
-        /// Version number of plugin
+        /// Version number of plug-in
         /// </summary>
         decimal Version { get; }
 
         /// <summary>
-        /// Description of what plugin does
+        /// Description of what plug-in does
         /// </summary>
         string Description { get; }
 
@@ -30,12 +30,12 @@ namespace Nikse.SubtitleEdit.PluginLogic
         string ActionType { get; }
 
         /// <summary>
-        /// Shortcut used to active plugin - e.g. Control+Shift+F9
+        /// Shortcut used to activate the plug-in - e.g. Control+Shift+F9
         /// </summary>
         string Shortcut { get; }
 
         /// <summary>
-        /// This action of callsed when Subtitle Edit calls plugin
+        /// This method is invoked when Subtitle Edit calls the plug-in
         /// </summary>
         /// <param name="parentForm">Main form in Subtitle Edit</param>
         /// <param name="subtitle">SubRip text</param>

--- a/AmericanToBritish/DLL/ManageWordsForm.Designer.cs
+++ b/AmericanToBritish/DLL/ManageWordsForm.Designer.cs
@@ -30,15 +30,15 @@
         {
             this.components = new System.ComponentModel.Container();
             this.listView1 = new System.Windows.Forms.ListView();
-            this.columnHeader1 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeaderAmerican = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeaderBritish = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.removeSelectedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemRemoveSelected = new System.Windows.Forms.ToolStripMenuItem();
             this.labelSource = new System.Windows.Forms.Label();
             this.buttonOK = new System.Windows.Forms.Button();
             this.labelTotalWords = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
+            this.labelAmerican = new System.Windows.Forms.Label();
+            this.labelBritish = new System.Windows.Forms.Label();
             this.textBoxAmerican = new System.Windows.Forms.TextBox();
             this.textBoxBritish = new System.Windows.Forms.TextBox();
             this.buttonAdd = new System.Windows.Forms.Button();
@@ -48,42 +48,42 @@
             // listView1
             // 
             this.listView1.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.columnHeader1,
-            this.columnHeader2});
+            this.columnHeaderAmerican,
+            this.columnHeaderBritish});
             this.listView1.ContextMenuStrip = this.contextMenuStrip1;
             this.listView1.FullRowSelect = true;
             this.listView1.GridLines = true;
-            this.listView1.Location = new System.Drawing.Point(12, 39);
+            this.listView1.Location = new System.Drawing.Point(12, 40);
             this.listView1.Name = "listView1";
-            this.listView1.Size = new System.Drawing.Size(620, 281);
+            this.listView1.Size = new System.Drawing.Size(620, 283);
             this.listView1.TabIndex = 0;
             this.listView1.UseCompatibleStateImageBehavior = false;
             this.listView1.View = System.Windows.Forms.View.Details;
             // 
-            // columnHeader1
+            // columnHeaderAmerican
             // 
-            this.columnHeader1.Text = "American";
-            this.columnHeader1.Width = 287;
+            this.columnHeaderAmerican.Text = "American";
+            this.columnHeaderAmerican.Width = 300;
             // 
-            // columnHeader2
+            // columnHeaderBritish
             // 
-            this.columnHeader2.Text = "British";
-            this.columnHeader2.Width = 325;
+            this.columnHeaderBritish.Text = "British";
+            this.columnHeaderBritish.Width = 299;
             // 
             // contextMenuStrip1
             // 
             this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.removeSelectedToolStripMenuItem});
+            this.toolStripMenuItemRemoveSelected});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
             this.contextMenuStrip1.Size = new System.Drawing.Size(164, 48);
             this.contextMenuStrip1.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip1_Opening);
             // 
-            // removeSelectedToolStripMenuItem
+            // toolStripMenuItemRemoveSelected
             // 
-            this.removeSelectedToolStripMenuItem.Name = "removeSelectedToolStripMenuItem";
-            this.removeSelectedToolStripMenuItem.Size = new System.Drawing.Size(163, 22);
-            this.removeSelectedToolStripMenuItem.Text = "Remove selected";
-            this.removeSelectedToolStripMenuItem.Click += new System.EventHandler(this.removeSelectedToolStripMenuItem_Click);
+            this.toolStripMenuItemRemoveSelected.Name = "toolStripMenuItemRemoveSelected";
+            this.toolStripMenuItemRemoveSelected.Size = new System.Drawing.Size(163, 22);
+            this.toolStripMenuItemRemoveSelected.Text = "Remove selected";
+            this.toolStripMenuItemRemoveSelected.Click += new System.EventHandler(this.toolStripMenuItemRemoveSelected_Click);
             // 
             // labelSource
             // 
@@ -96,7 +96,7 @@
             // 
             // buttonOK
             // 
-            this.buttonOK.Location = new System.Drawing.Point(557, 326);
+            this.buttonOK.Location = new System.Drawing.Point(557, 332);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
             this.buttonOK.TabIndex = 2;
@@ -107,29 +107,29 @@
             // labelTotalWords
             // 
             this.labelTotalWords.AutoSize = true;
-            this.labelTotalWords.Location = new System.Drawing.Point(12, 326);
+            this.labelTotalWords.Location = new System.Drawing.Point(12, 332);
             this.labelTotalWords.Name = "labelTotalWords";
             this.labelTotalWords.Size = new System.Drawing.Size(65, 13);
             this.labelTotalWords.TabIndex = 3;
             this.labelTotalWords.Text = "Total words:";
             // 
-            // label1
+            // labelAmerican
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(220, 14);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(54, 13);
-            this.label1.TabIndex = 4;
-            this.label1.Text = "American:";
+            this.labelAmerican.AutoSize = true;
+            this.labelAmerican.Location = new System.Drawing.Point(220, 14);
+            this.labelAmerican.Name = "labelAmerican";
+            this.labelAmerican.Size = new System.Drawing.Size(54, 13);
+            this.labelAmerican.TabIndex = 4;
+            this.labelAmerican.Text = "American:";
             // 
-            // label2
+            // labelBritish
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(408, 14);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(38, 13);
-            this.label2.TabIndex = 5;
-            this.label2.Text = "British:";
+            this.labelBritish.AutoSize = true;
+            this.labelBritish.Location = new System.Drawing.Point(408, 14);
+            this.labelBritish.Name = "labelBritish";
+            this.labelBritish.Size = new System.Drawing.Size(38, 13);
+            this.labelBritish.TabIndex = 5;
+            this.labelBritish.Text = "British:";
             // 
             // textBoxAmerican
             // 
@@ -163,8 +163,8 @@
             this.Controls.Add(this.buttonAdd);
             this.Controls.Add(this.textBoxBritish);
             this.Controls.Add(this.textBoxAmerican);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.label1);
+            this.Controls.Add(this.labelBritish);
+            this.Controls.Add(this.labelAmerican);
             this.Controls.Add(this.labelTotalWords);
             this.Controls.Add(this.buttonOK);
             this.Controls.Add(this.labelSource);
@@ -173,7 +173,7 @@
             this.MinimumSize = new System.Drawing.Size(660, 394);
             this.Name = "ManageWordsForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "List words manager";
+            this.Text = "Word list manager";
             this.contextMenuStrip1.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -183,17 +183,17 @@
         #endregion
 
         private System.Windows.Forms.ListView listView1;
-        private System.Windows.Forms.ColumnHeader columnHeader1;
-        private System.Windows.Forms.ColumnHeader columnHeader2;
+        private System.Windows.Forms.ColumnHeader columnHeaderAmerican;
+        private System.Windows.Forms.ColumnHeader columnHeaderBritish;
         private System.Windows.Forms.Label labelSource;
         private System.Windows.Forms.Button buttonOK;
         private System.Windows.Forms.Label labelTotalWords;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label labelAmerican;
+        private System.Windows.Forms.Label labelBritish;
         private System.Windows.Forms.TextBox textBoxAmerican;
         private System.Windows.Forms.TextBox textBoxBritish;
         private System.Windows.Forms.Button buttonAdd;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
-        private System.Windows.Forms.ToolStripMenuItem removeSelectedToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemRemoveSelected;
     }
 }

--- a/AmericanToBritish/DLL/ManageWordsForm.cs
+++ b/AmericanToBritish/DLL/ManageWordsForm.cs
@@ -44,19 +44,38 @@ namespace Nikse.SubtitleEdit.PluginLogic
 
         private void buttonAdd_Click(object sender, EventArgs e)
         {
-            // validate both words
-            if (string.IsNullOrWhiteSpace(textBoxAmerican.Text) || string.IsNullOrWhiteSpace(textBoxBritish.Text) || (textBoxAmerican.Text == textBoxBritish.Text))
-                return;
+            var americanWord = textBoxAmerican.Text.Trim().ToLowerInvariant();
+            var britishWord = textBoxBritish.Text.Trim().ToLowerInvariant();
 
-            if (_xdoc?.Root?.Name == "Words")
+            if (americanWord.Length > 0)
             {
-                _xdoc.Root.Add(new XElement("Word", new XAttribute("us", textBoxAmerican.Text), new XAttribute("br", textBoxBritish.Text)));
-                textBoxAmerican.Text = string.Empty;
-                textBoxBritish.Text = string.Empty;
-                // reload listview
-                GeneratePreview();
-                MessageBox.Show($"Added: American: {textBoxAmerican.Text}; British: {textBoxBritish.Text}");
+                foreach (ListViewItem item in listView1.Items)
+                {
+                    if (americanWord == item.Text.ToLowerInvariant())
+                    {
+                        listView1.SelectedItems.Clear();
+                        item.EnsureVisible();
+                        item.Selected = true;
+                        item.Focused = true;
+                        listView1.Select();
+                        return;
+                    }
+                }
+                if (britishWord.Length == 0 || americanWord == britishWord)
+                {
+                    textBoxBritish.Select();
+                    return;
+                }
+                if (_xdoc?.Root?.Name == "Words")
+                {
+                    _xdoc.Root.Add(new XElement("Word", new XAttribute("us", americanWord), new XAttribute("br", britishWord)));
+                    textBoxAmerican.Text = string.Empty;
+                    textBoxBritish.Text = string.Empty;
+                    GeneratePreview();
+                    MessageBox.Show($"Added: American: {americanWord}; British: {britishWord}");
+                }
             }
+            textBoxAmerican.Select();
         }
 
         private void GeneratePreview()

--- a/AmericanToBritish/DLL/ManageWordsForm.cs
+++ b/AmericanToBritish/DLL/ManageWordsForm.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using System.Xml;
 using System.Xml.Linq;
 
 namespace Nikse.SubtitleEdit.PluginLogic
@@ -17,6 +11,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
         // readonly for built-in list
         private XDocument _xdoc;
         private string _path;
+
         public ManageWordsForm()
         {
             InitializeComponent();
@@ -24,7 +19,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
 
         public void Initialize(string path)
         {
-            labelSource.Text = $"Source: Local-List";
+            labelSource.Text = "Source: Local-List";
             _path = path;
             _xdoc = XDocument.Load(path);
             GeneratePreview();
@@ -32,7 +27,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
 
         public void Initialize(Stream stream)
         {
-            labelSource.Text = $"Source: Embadded-List";
+            labelSource.Text = "Source: Embedded-List";
             textBoxAmerican.Enabled = false;
             textBoxBritish.Enabled = false;
             buttonAdd.Enabled = false;
@@ -40,18 +35,11 @@ namespace Nikse.SubtitleEdit.PluginLogic
             GeneratePreview();
         }
 
-        private void AddToListView(string americanWord, string britishWord, XElement elem)
-        {
-            var item = new ListViewItem(americanWord) { Tag = elem };
-            item.SubItems.Add(britishWord);
-            listView1.Items.Add(item);
-        }
-
         private void buttonOK_Click(object sender, EventArgs e)
         {
-            DialogResult = DialogResult.OK;
             if (!string.IsNullOrEmpty(_path))
                 _xdoc.Save(_path);
+            DialogResult = DialogResult.OK;
         }
 
         private void buttonAdd_Click(object sender, EventArgs e)
@@ -73,37 +61,39 @@ namespace Nikse.SubtitleEdit.PluginLogic
 
         private void GeneratePreview()
         {
-            var totalWords = 0;
             listView1.BeginUpdate();
             listView1.Items.Clear();
             if (_xdoc?.Root?.Name == "Words")
             {
                 foreach (var item in _xdoc.Root.Elements("Word"))
                 {
-                    if (item.Attribute("us")?.Value.Length > 1 && item.Attribute("br")?.Value.Length > 1)
+                    if (item.Attribute("us")?.Value.Length > 0 && item.Attribute("br")?.Value.Length > 0)
                     {
-                        AddToListView(item.Attribute("us")?.Value, item.Attribute("br")?.Value, item);
-                        totalWords++;
+                        AddToListView(item.Attribute("us").Value, item.Attribute("br").Value, item);
                     }
                 }
             }
             listView1.EndUpdate();
-            labelTotalWords.Text = $"Total words: {totalWords}";
+            labelTotalWords.Text = $"Total words: {listView1.Items.Count}";
         }
 
-        private void removeSelectedToolStripMenuItem_Click(object sender, EventArgs e)
+        private void AddToListView(string americanWord, string britishWord, XElement elem)
         {
-            if (listView1.SelectedIndices.Count == 0)
+            var item = new ListViewItem(americanWord) { Tag = elem };
+            item.SubItems.Add(britishWord);
+            listView1.Items.Add(item);
+        }
+
+        private void toolStripMenuItemRemoveSelected_Click(object sender, EventArgs e)
+        {
+            if (listView1.SelectedItems.Count > 0)
             {
-                return;
+                foreach (ListViewItem item in listView1.SelectedItems)
+                {
+                    (item.Tag as XElement).Remove();
+                }
+                GeneratePreview();
             }
-            foreach (ListViewItem item in listView1.SelectedItems)
-            {
-                var r = ((XElement)item.Tag);
-                _xdoc.Root.Elements().Where(el => el == r).First().Remove();
-                item.Remove();
-            }
-            GeneratePreview();
         }
 
         private void contextMenuStrip1_Opening(object sender, CancelEventArgs e)
@@ -111,5 +101,6 @@ namespace Nikse.SubtitleEdit.PluginLogic
             if (_path == null)
                 e.Cancel = true;
         }
+
     }
 }

--- a/AmericanToBritish/DLL/Plugin.cs
+++ b/AmericanToBritish/DLL/Plugin.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿using Nikse.SubtitleEdit.PluginLogic.Logic;
 using System.Linq;
 using System.Windows.Forms;
-using Nikse.SubtitleEdit.PluginLogic.Logic;
 
 namespace Nikse.SubtitleEdit.PluginLogic
 {
@@ -41,23 +40,22 @@ namespace Nikse.SubtitleEdit.PluginLogic
         {
             if (string.IsNullOrWhiteSpace(subtitle))
             {
-                MessageBox.Show("No subtitle loaded", parentForm.Text,
-                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show("No subtitle loaded", parentForm.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return string.Empty;
             }
 
             if (!string.IsNullOrEmpty(listViewLineSeparatorString))
                 Configuration.ListViewLineSeparatorString = listViewLineSeparatorString;
 
-            var list = subtitle.Replace(Environment.NewLine, "\n").Split('\n').ToList();
+            var list = subtitle.SplitToLines().ToList();
 
             var sub = new Subtitle();
             var srt = new SubRip();
             srt.LoadSubtitle(sub, list, subtitleFileName);
             if (srt.Errors > 0)
             {
-                MessageBox.Show(srt.Errors + " Errors found while parsing .srt",
-                    "Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                var s = srt.Errors > 1 ? "s" : string.Empty;
+                MessageBox.Show($"{srt.Errors} error{s} found while parsing .srt", "Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
             using (var form = new PluginForm(sub, (this as IPlugin).Name, (this as IPlugin).Description))
             {
@@ -66,5 +64,6 @@ namespace Nikse.SubtitleEdit.PluginLogic
             }
             return string.Empty;
         }
+
     }
 }

--- a/AmericanToBritish/DLL/PluginForm.Designer.cs
+++ b/AmericanToBritish/DLL/PluginForm.Designer.cs
@@ -279,7 +279,7 @@
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "PluginForm";
-            this.Load += new System.EventHandler(this.PluginForm_Load);
+            this.Shown += new System.EventHandler(this.PluginForm_Shown);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.PluginForm_KeyDown);
             this.Resize += new System.EventHandler(this.PluginForm_Resize);
             this.contextMenuStrip1.ResumeLayout(false);

--- a/AmericanToBritish/DLL/PluginForm.Designer.cs
+++ b/AmericanToBritish/DLL/PluginForm.Designer.cs
@@ -30,7 +30,7 @@
         {
             this.components = new System.ComponentModel.Container();
             this.buttonOK = new System.Windows.Forms.Button();
-            this.button1 = new System.Windows.Forms.Button();
+            this.buttonCancel = new System.Windows.Forms.Button();
             this.labelDescription = new System.Windows.Forms.Label();
             this.listViewFixes = new System.Windows.Forms.ListView();
             this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -38,18 +38,18 @@
             this.columnHeader7 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.selectAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.invertToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemSelectAll = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemInvert = new System.Windows.Forms.ToolStripMenuItem();
             this.labelTotal = new System.Windows.Forms.Label();
-            this.linkLabel1 = new System.Windows.Forms.LinkLabel();
-            this.linkLabel2 = new System.Windows.Forms.LinkLabel();
+            this.linkLabelIssues = new System.Windows.Forms.LinkLabel();
+            this.linkLabelWordList = new System.Windows.Forms.LinkLabel();
             this.radioButtonBuiltInList = new System.Windows.Forms.RadioButton();
             this.radioButtonLocalList = new System.Windows.Forms.RadioButton();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.manageLocalwordsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.viewBuiltinWordsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
+            this.toolStripMenuItemFile = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemManageLocalWords = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItemViewBuiltInWords = new System.Windows.Forms.ToolStripMenuItem();
+            this.checkBoxNoBuiltIn = new System.Windows.Forms.CheckBox();
             this.contextMenuStrip1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -65,16 +65,16 @@
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);
             // 
-            // button1
+            // buttonCancel
             // 
-            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.button1.Location = new System.Drawing.Point(779, 437);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
-            this.button1.TabIndex = 3;
-            this.button1.Text = "C&ancel";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.buttonCancel_Click);
+            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonCancel.Location = new System.Drawing.Point(779, 437);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonCancel.TabIndex = 3;
+            this.buttonCancel.Text = "C&ancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
             // 
             // labelDescription
             // 
@@ -114,7 +114,7 @@
             // 
             // columnHeader5
             // 
-            this.columnHeader5.Text = "Line#";
+            this.columnHeader5.Text = "Line #";
             this.columnHeader5.Width = 50;
             // 
             // columnHeader7
@@ -130,24 +130,24 @@
             // contextMenuStrip1
             // 
             this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.selectAllToolStripMenuItem,
-            this.invertToolStripMenuItem});
+            this.toolStripMenuItemSelectAll,
+            this.toolStripMenuItemInvert});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
             this.contextMenuStrip1.Size = new System.Drawing.Size(155, 48);
             // 
-            // selectAllToolStripMenuItem
+            // toolStripMenuItemSelectAll
             // 
-            this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
-            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
-            this.selectAllToolStripMenuItem.Text = "Select all";
-            this.selectAllToolStripMenuItem.Click += new System.EventHandler(this.selectAllToolStripMenuItem_Click);
+            this.toolStripMenuItemSelectAll.Name = "toolStripMenuItemSelectAll";
+            this.toolStripMenuItemSelectAll.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItemSelectAll.Text = "Select all";
+            this.toolStripMenuItemSelectAll.Click += new System.EventHandler(this.toolStripMenuItemSelectAll_Click);
             // 
-            // invertToolStripMenuItem
+            // toolStripMenuItemInvert
             // 
-            this.invertToolStripMenuItem.Name = "invertToolStripMenuItem";
-            this.invertToolStripMenuItem.Size = new System.Drawing.Size(154, 22);
-            this.invertToolStripMenuItem.Text = "Invert selection";
-            this.invertToolStripMenuItem.Click += new System.EventHandler(this.invertToolStripMenuItem_Click);
+            this.toolStripMenuItemInvert.Name = "toolStripMenuItemInvert";
+            this.toolStripMenuItemInvert.Size = new System.Drawing.Size(154, 22);
+            this.toolStripMenuItemInvert.Text = "Invert selection";
+            this.toolStripMenuItemInvert.Click += new System.EventHandler(this.toolStripMenuItemInvert_Click);
             // 
             // labelTotal
             // 
@@ -159,29 +159,29 @@
             this.labelTotal.TabIndex = 1;
             this.labelTotal.Text = "Total:";
             // 
-            // linkLabel1
+            // linkLabelIssues
             // 
-            this.linkLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.linkLabel1.AutoSize = true;
-            this.linkLabel1.Location = new System.Drawing.Point(12, 451);
-            this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(111, 13);
-            this.linkLabel1.TabIndex = 6;
-            this.linkLabel1.TabStop = true;
-            this.linkLabel1.Text = "Report missing word...";
-            this.linkLabel1.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel1_LinkClicked);
+            this.linkLabelIssues.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.linkLabelIssues.AutoSize = true;
+            this.linkLabelIssues.Location = new System.Drawing.Point(12, 451);
+            this.linkLabelIssues.Name = "linkLabelIssues";
+            this.linkLabelIssues.Size = new System.Drawing.Size(111, 13);
+            this.linkLabelIssues.TabIndex = 6;
+            this.linkLabelIssues.TabStop = true;
+            this.linkLabelIssues.Text = "Report missing word...";
+            this.linkLabelIssues.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelIssues_LinkClicked);
             // 
-            // linkLabel2
+            // linkLabelWordList
             // 
-            this.linkLabel2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.linkLabel2.AutoSize = true;
-            this.linkLabel2.Location = new System.Drawing.Point(129, 451);
-            this.linkLabel2.Name = "linkLabel2";
-            this.linkLabel2.Size = new System.Drawing.Size(80, 13);
-            this.linkLabel2.TabIndex = 5;
-            this.linkLabel2.TabStop = true;
-            this.linkLabel2.Text = "View word list...";
-            this.linkLabel2.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel2_LinkClicked);
+            this.linkLabelWordList.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.linkLabelWordList.AutoSize = true;
+            this.linkLabelWordList.Location = new System.Drawing.Point(129, 451);
+            this.linkLabelWordList.Name = "linkLabelWordList";
+            this.linkLabelWordList.Size = new System.Drawing.Size(80, 13);
+            this.linkLabelWordList.TabIndex = 5;
+            this.linkLabelWordList.TabStop = true;
+            this.linkLabelWordList.Text = "View word list...";
+            this.linkLabelWordList.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelWordList_LinkClicked);
             // 
             // radioButtonBuiltInList
             // 
@@ -212,62 +212,62 @@
             // menuStrip1
             // 
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem});
+            this.toolStripMenuItemFile});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Size = new System.Drawing.Size(866, 24);
             this.menuStrip1.TabIndex = 11;
             this.menuStrip1.Text = "menuStrip1";
             // 
-            // fileToolStripMenuItem
+            // toolStripMenuItemFile
             // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.manageLocalwordsToolStripMenuItem,
-            this.viewBuiltinWordsToolStripMenuItem});
-            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-            this.fileToolStripMenuItem.Text = "File";
+            this.toolStripMenuItemFile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripMenuItemManageLocalWords,
+            this.toolStripMenuItemViewBuiltInWords});
+            this.toolStripMenuItemFile.Name = "toolStripMenuItemFile";
+            this.toolStripMenuItemFile.Size = new System.Drawing.Size(37, 20);
+            this.toolStripMenuItemFile.Text = "File";
             // 
-            // manageLocalwordsToolStripMenuItem
+            // toolStripMenuItemManageLocalWords
             // 
-            this.manageLocalwordsToolStripMenuItem.Name = "manageLocalwordsToolStripMenuItem";
-            this.manageLocalwordsToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
-            this.manageLocalwordsToolStripMenuItem.Text = "Manage local-words";
-            this.manageLocalwordsToolStripMenuItem.Click += new System.EventHandler(this.manageLocalwordsToolStripMenuItem_Click);
+            this.toolStripMenuItemManageLocalWords.Name = "toolStripMenuItemManageLocalWords";
+            this.toolStripMenuItemManageLocalWords.Size = new System.Drawing.Size(193, 22);
+            this.toolStripMenuItemManageLocalWords.Text = "Manage local word list";
+            this.toolStripMenuItemManageLocalWords.Click += new System.EventHandler(this.toolStripMenuItemManageLocalwords_Click);
             // 
-            // viewBuiltinWordsToolStripMenuItem
+            // toolStripMenuItemViewBuiltInWords
             // 
-            this.viewBuiltinWordsToolStripMenuItem.Name = "viewBuiltinWordsToolStripMenuItem";
-            this.viewBuiltinWordsToolStripMenuItem.Size = new System.Drawing.Size(182, 22);
-            this.viewBuiltinWordsToolStripMenuItem.Text = "View built-in words";
-            this.viewBuiltinWordsToolStripMenuItem.Click += new System.EventHandler(this.viewBuiltinWordsToolStripMenuItem_Click);
+            this.toolStripMenuItemViewBuiltInWords.Name = "toolStripMenuItemViewBuiltInWords";
+            this.toolStripMenuItemViewBuiltInWords.Size = new System.Drawing.Size(193, 22);
+            this.toolStripMenuItemViewBuiltInWords.Text = "View built-in word list";
+            this.toolStripMenuItemViewBuiltInWords.Click += new System.EventHandler(this.toolStripMenuItemViewBuiltInWords_Click);
             // 
-            // checkBox1
+            // checkBoxNoBuiltIn
             // 
-            this.checkBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.checkBox1.AutoSize = true;
-            this.checkBox1.Location = new System.Drawing.Point(758, 23);
-            this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(96, 17);
-            this.checkBox1.TabIndex = 12;
-            this.checkBox1.Text = "Disalble built-in";
-            this.checkBox1.UseVisualStyleBackColor = true;
-            this.checkBox1.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
+            this.checkBoxNoBuiltIn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.checkBoxNoBuiltIn.AutoSize = true;
+            this.checkBoxNoBuiltIn.Location = new System.Drawing.Point(758, 23);
+            this.checkBoxNoBuiltIn.Name = "checkBoxNoBuiltIn";
+            this.checkBoxNoBuiltIn.Size = new System.Drawing.Size(96, 17);
+            this.checkBoxNoBuiltIn.TabIndex = 12;
+            this.checkBoxNoBuiltIn.Text = "Disable built-in";
+            this.checkBoxNoBuiltIn.UseVisualStyleBackColor = true;
+            this.checkBoxNoBuiltIn.CheckedChanged += new System.EventHandler(this.checkBoxNoBuiltIn_CheckedChanged);
             // 
             // PluginForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(866, 473);
-            this.Controls.Add(this.checkBox1);
+            this.Controls.Add(this.checkBoxNoBuiltIn);
             this.Controls.Add(this.radioButtonLocalList);
             this.Controls.Add(this.radioButtonBuiltInList);
-            this.Controls.Add(this.linkLabel2);
-            this.Controls.Add(this.linkLabel1);
+            this.Controls.Add(this.linkLabelWordList);
+            this.Controls.Add(this.linkLabelIssues);
             this.Controls.Add(this.labelTotal);
             this.Controls.Add(this.listViewFixes);
             this.Controls.Add(this.labelDescription);
-            this.Controls.Add(this.button1);
+            this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.buttonOK);
             this.Controls.Add(this.menuStrip1);
             this.KeyPreview = true;
@@ -293,7 +293,7 @@
         #endregion
 
         private System.Windows.Forms.Button buttonOK;
-        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.Label labelDescription;
         private System.Windows.Forms.ListView listViewFixes;
         private System.Windows.Forms.ColumnHeader columnHeader4;
@@ -301,17 +301,17 @@
         private System.Windows.Forms.ColumnHeader columnHeader7;
         private System.Windows.Forms.ColumnHeader columnHeader8;
         private System.Windows.Forms.Label labelTotal;
-        private System.Windows.Forms.LinkLabel linkLabel1;
-        private System.Windows.Forms.LinkLabel linkLabel2;
+        private System.Windows.Forms.LinkLabel linkLabelIssues;
+        private System.Windows.Forms.LinkLabel linkLabelWordList;
         private System.Windows.Forms.RadioButton radioButtonBuiltInList;
         private System.Windows.Forms.RadioButton radioButtonLocalList;
         private System.Windows.Forms.MenuStrip menuStrip1;
-        private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem manageLocalwordsToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem viewBuiltinWordsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemFile;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemManageLocalWords;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemViewBuiltInWords;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
-        private System.Windows.Forms.ToolStripMenuItem selectAllToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem invertToolStripMenuItem;
-        private System.Windows.Forms.CheckBox checkBox1;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemSelectAll;
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemInvert;
+        private System.Windows.Forms.CheckBox checkBoxNoBuiltIn;
     }
 }

--- a/AmericanToBritish/DLL/PluginForm.Designer.cs
+++ b/AmericanToBritish/DLL/PluginForm.Designer.cs
@@ -45,11 +45,11 @@
             this.linkLabelWordList = new System.Windows.Forms.LinkLabel();
             this.radioButtonBuiltInList = new System.Windows.Forms.RadioButton();
             this.radioButtonLocalList = new System.Windows.Forms.RadioButton();
+            this.radioButtonBothLists = new System.Windows.Forms.RadioButton();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.toolStripMenuItemFile = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemManageLocalWords = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItemViewBuiltInWords = new System.Windows.Forms.ToolStripMenuItem();
-            this.checkBoxNoBuiltIn = new System.Windows.Forms.CheckBox();
             this.contextMenuStrip1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -166,7 +166,7 @@
             this.linkLabelIssues.Location = new System.Drawing.Point(12, 451);
             this.linkLabelIssues.Name = "linkLabelIssues";
             this.linkLabelIssues.Size = new System.Drawing.Size(111, 13);
-            this.linkLabelIssues.TabIndex = 6;
+            this.linkLabelIssues.TabIndex = 5;
             this.linkLabelIssues.TabStop = true;
             this.linkLabelIssues.Text = "Report missing word...";
             this.linkLabelIssues.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelIssues_LinkClicked);
@@ -178,7 +178,7 @@
             this.linkLabelWordList.Location = new System.Drawing.Point(129, 451);
             this.linkLabelWordList.Name = "linkLabelWordList";
             this.linkLabelWordList.Size = new System.Drawing.Size(80, 13);
-            this.linkLabelWordList.TabIndex = 5;
+            this.linkLabelWordList.TabIndex = 6;
             this.linkLabelWordList.TabStop = true;
             this.linkLabelWordList.Text = "View word list...";
             this.linkLabelWordList.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabelWordList_LinkClicked);
@@ -188,10 +188,10 @@
             this.radioButtonBuiltInList.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.radioButtonBuiltInList.AutoSize = true;
             this.radioButtonBuiltInList.Checked = true;
-            this.radioButtonBuiltInList.Location = new System.Drawing.Point(566, 23);
+            this.radioButtonBuiltInList.Location = new System.Drawing.Point(578, 23);
             this.radioButtonBuiltInList.Name = "radioButtonBuiltInList";
             this.radioButtonBuiltInList.Size = new System.Drawing.Size(92, 17);
-            this.radioButtonBuiltInList.TabIndex = 9;
+            this.radioButtonBuiltInList.TabIndex = 7;
             this.radioButtonBuiltInList.TabStop = true;
             this.radioButtonBuiltInList.Text = "Use built-in list";
             this.radioButtonBuiltInList.UseVisualStyleBackColor = true;
@@ -201,13 +201,25 @@
             // 
             this.radioButtonLocalList.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.radioButtonLocalList.AutoSize = true;
-            this.radioButtonLocalList.Location = new System.Drawing.Point(664, 23);
+            this.radioButtonLocalList.Location = new System.Drawing.Point(676, 23);
             this.radioButtonLocalList.Name = "radioButtonLocalList";
             this.radioButtonLocalList.Size = new System.Drawing.Size(84, 17);
-            this.radioButtonLocalList.TabIndex = 10;
+            this.radioButtonLocalList.TabIndex = 8;
             this.radioButtonLocalList.Text = "Use local list";
             this.radioButtonLocalList.UseVisualStyleBackColor = true;
             this.radioButtonLocalList.Click += new System.EventHandler(this.radioButtonLocalList_Click);
+            // 
+            // radioButtonBothLists
+            // 
+            this.radioButtonBothLists.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.radioButtonBothLists.AutoSize = true;
+            this.radioButtonBothLists.Location = new System.Drawing.Point(766, 23);
+            this.radioButtonBothLists.Name = "radioButtonBothLists";
+            this.radioButtonBothLists.Size = new System.Drawing.Size(88, 17);
+            this.radioButtonBothLists.TabIndex = 9;
+            this.radioButtonBothLists.Text = "Use both lists";
+            this.radioButtonBothLists.UseVisualStyleBackColor = true;
+            this.radioButtonBothLists.Click += new System.EventHandler(this.radioButtonBothLists_Click);
             // 
             // menuStrip1
             // 
@@ -216,7 +228,7 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Size = new System.Drawing.Size(866, 24);
-            this.menuStrip1.TabIndex = 11;
+            this.menuStrip1.TabIndex = 10;
             this.menuStrip1.Text = "menuStrip1";
             // 
             // toolStripMenuItemFile
@@ -242,24 +254,12 @@
             this.toolStripMenuItemViewBuiltInWords.Text = "View built-in word list";
             this.toolStripMenuItemViewBuiltInWords.Click += new System.EventHandler(this.toolStripMenuItemViewBuiltInWords_Click);
             // 
-            // checkBoxNoBuiltIn
-            // 
-            this.checkBoxNoBuiltIn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.checkBoxNoBuiltIn.AutoSize = true;
-            this.checkBoxNoBuiltIn.Location = new System.Drawing.Point(758, 23);
-            this.checkBoxNoBuiltIn.Name = "checkBoxNoBuiltIn";
-            this.checkBoxNoBuiltIn.Size = new System.Drawing.Size(96, 17);
-            this.checkBoxNoBuiltIn.TabIndex = 12;
-            this.checkBoxNoBuiltIn.Text = "Disable built-in";
-            this.checkBoxNoBuiltIn.UseVisualStyleBackColor = true;
-            this.checkBoxNoBuiltIn.CheckedChanged += new System.EventHandler(this.checkBoxNoBuiltIn_CheckedChanged);
-            // 
             // PluginForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(866, 473);
-            this.Controls.Add(this.checkBoxNoBuiltIn);
+            this.Controls.Add(this.radioButtonBothLists);
             this.Controls.Add(this.radioButtonLocalList);
             this.Controls.Add(this.radioButtonBuiltInList);
             this.Controls.Add(this.linkLabelWordList);
@@ -305,6 +305,7 @@
         private System.Windows.Forms.LinkLabel linkLabelWordList;
         private System.Windows.Forms.RadioButton radioButtonBuiltInList;
         private System.Windows.Forms.RadioButton radioButtonLocalList;
+        private System.Windows.Forms.RadioButton radioButtonBothLists;
         private System.Windows.Forms.MenuStrip menuStrip1;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemFile;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemManageLocalWords;
@@ -312,6 +313,5 @@
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemSelectAll;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemInvert;
-        private System.Windows.Forms.CheckBox checkBoxNoBuiltIn;
     }
 }

--- a/AmericanToBritish/DLL/PluginForm.cs
+++ b/AmericanToBritish/DLL/PluginForm.cs
@@ -18,6 +18,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
         private bool _allowFixes;
         private AmericanToBritishConverter _converter;
         private string _localFile;
+
         internal PluginForm(Subtitle subtitle, string name, string description)
         {
             InitializeComponent();
@@ -43,11 +44,11 @@ namespace Nikse.SubtitleEdit.PluginLogic
             // deserialize checkbox status
             try
             {
-                var xmldoc = new System.Xml.XmlDocument();
+                var xmldoc = new System.Xml.XmlDocument { XmlResolver = null };
                 xmldoc.Load(_localFile);
                 var xnode = xmldoc.SelectSingleNode("Words");
                 var state = Convert.ToBoolean(xnode.Attributes["NoBuiltIn"].InnerText);
-                checkBox1.Checked = state;
+                checkBoxNoBuiltIn.Checked = state;
             }
             catch
             {
@@ -62,7 +63,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
                     xmldoc.Load(_localFile);
                     var xnode = xmldoc.SelectSingleNode("Words");
                     var attrib = xmldoc.CreateAttribute("NoBuiltIn");
-                    attrib.InnerText = checkBox1.Checked.ToString();
+                    attrib.InnerText = checkBoxNoBuiltIn.Checked.ToString();
                     xnode.Attributes.Append(attrib);
                     xmldoc.Save(_localFile);
                 }
@@ -152,9 +153,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
 
         private bool SubtitleLoaded()
         {
-            if (_subtitle == null || _subtitle.Paragraphs.Count < 1)
-                return false;
-            return true;
+            return _subtitle != null && _subtitle.Paragraphs.Count > 0;
         }
 
         private void DoSelection(bool selectAll)
@@ -190,12 +189,12 @@ namespace Nikse.SubtitleEdit.PluginLogic
             }
         }
 
-        private void linkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void linkLabelIssues_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start("https://github.com/SubtitleEdit/plugins/issues/new");
         }
 
-        private void linkLabel2_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void linkLabelWordList_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start("https://github.com/SubtitleEdit/plugins/blob/master/AmericanToBritish/DLL/WordList.xml");
         }
@@ -211,7 +210,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
                 DialogResult = DialogResult.Cancel;
         }
 
-        private void manageLocalwordsToolStripMenuItem_Click(object sender, EventArgs e)
+        private void toolStripMenuItemManageLocalwords_Click(object sender, EventArgs e)
         {
             if (!File.Exists(_localFile))
                 return;
@@ -225,7 +224,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
                 GeneratePreview();
         }
 
-        private void viewBuiltinWordsToolStripMenuItem_Click(object sender, EventArgs e)
+        private void toolStripMenuItemViewBuiltInWords_Click(object sender, EventArgs e)
         {
             using (var manageWords = new ManageWordsForm())
             using (var resouceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Nikse.SubtitleEdit.PluginLogic.WordList.xml"))
@@ -244,25 +243,25 @@ namespace Nikse.SubtitleEdit.PluginLogic
             }
         }
 
-        private void selectAllToolStripMenuItem_Click(object sender, EventArgs e)
+        private void toolStripMenuItemSelectAll_Click(object sender, EventArgs e)
         {
             if (!SubtitleLoaded())
                 return;
             DoSelection(true);
         }
 
-        private void invertToolStripMenuItem_Click(object sender, EventArgs e)
+        private void toolStripMenuItemInvert_Click(object sender, EventArgs e)
         {
             if (!SubtitleLoaded())
                 return;
             DoSelection(false);
         }
 
-        private void checkBox1_CheckedChanged(object sender, EventArgs e)
+        private void checkBoxNoBuiltIn_CheckedChanged(object sender, EventArgs e)
         {
-            radioButtonLocalList.Enabled = !checkBox1.Checked;
-            radioButtonBuiltInList.Enabled = !checkBox1.Checked;
-            if (checkBox1.Checked)
+            radioButtonLocalList.Enabled = !checkBoxNoBuiltIn.Checked;
+            radioButtonBuiltInList.Enabled = !checkBoxNoBuiltIn.Checked;
+            if (checkBoxNoBuiltIn.Checked)
             {
                 radioButtonLocalList.Checked = true;
                 radioButtonLocalList_Click(this, EventArgs.Empty);
@@ -306,5 +305,6 @@ namespace Nikse.SubtitleEdit.PluginLogic
             // update list view
             GeneratePreview();
         }
+
     }
 }

--- a/AmericanToBritish/DLL/PluginForm.cs
+++ b/AmericanToBritish/DLL/PluginForm.cs
@@ -132,9 +132,11 @@ namespace Nikse.SubtitleEdit.PluginLogic
             Refresh();
         }
 
-        private void PluginForm_Load(object sender, EventArgs e)
+        private void PluginForm_Shown(object sender, EventArgs e)
         {
             Cursor = Cursors.WaitCursor;
+            Enabled = false;
+            Refresh();
             try
             {
                 if (_converter.LoadLocalWords(_localFileName))
@@ -155,6 +157,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
                     _converter.LoadBuiltInWords();
                 }
                 GeneratePreview();
+                Enabled = true;
             }
             catch (Exception exception)
             {
@@ -169,11 +172,13 @@ namespace Nikse.SubtitleEdit.PluginLogic
         private void linkLabelIssues_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start("https://github.com/SubtitleEdit/plugins/issues/new");
+            listViewFixes.Select();
         }
 
         private void linkLabelWordList_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start("https://github.com/SubtitleEdit/plugins/blob/master/AmericanToBritish/DLL/WordList.xml");
+            listViewFixes.Select();
         }
 
         private void PluginForm_Resize(object sender, EventArgs e)


### PR DESCRIPTION
    The local word list could be used to replace the embedded
    word list, now it can also be used as an extension to the
    embedded word list.

Without `RegexOptions.Compiled` the plug-in blocks the UI for a significantly shorter period of time.
