### PR TITLE
[AmericanToBritish] Direct users to GitHub "missing words" issue

### DIFF
--- a/AmericanToBritish/DLL/PluginForm.cs
+++ b/AmericanToBritish/DLL/PluginForm.cs
@@ -188,7 +188,7 @@ namespace Nikse.SubtitleEdit.PluginLogic
 
         private void linkLabelIssues_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start("https://github.com/SubtitleEdit/plugins/issues/new");
+            Process.Start("https://github.com/SubtitleEdit/plugins/issues/162");
             listViewFixes.Select();
         }
 


### PR DESCRIPTION
@ivandrofly 
This would direct users who want to report missing words to the _right_ issue, rather than opening a new, similar issue. And, should they have found a different kind of problem, there is always the **New issue** button in the top right corner.

 What do you think?