### PR TITLE
Add Dialogue Balancer plugin source

### DIFF
--- a/source/DialogueBalancer/DLL/DialogueBalancer.csproj
+++ b/source/DialogueBalancer/DLL/DialogueBalancer.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8A9B25A7-8869-450F-87C2-113AD0ADDEE7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DialogueBalancer</RootNamespace>
+    <AssemblyName>DialogueBalancer</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Logic\Configuration.cs" />
+    <Compile Include="IPlugin.cs" />
+    <Compile Include="Logic\Paragraph.cs" />
+    <Compile Include="Plugin.cs" />
+    <Compile Include="PluginForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="PluginForm.Designer.cs">
+      <DependentUpon>PluginForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Logic\SubRip.cs" />
+    <Compile Include="Logic\Subtitle.cs" />
+    <Compile Include="Logic\SubtitleFormat.cs" />
+    <Compile Include="Logic\TimeCode.cs" />
+    <Compile Include="Logic\Utilities.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="PluginForm.resx">
+      <DependentUpon>PluginForm.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/source/DialogueBalancer/DLL/IPlugin.cs
+++ b/source/DialogueBalancer/DLL/IPlugin.cs
@@ -1,0 +1,49 @@
+﻿using System.Windows.Forms;
+
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    interface IPlugin
+    {
+        /// <summary>
+        /// Name of the plug-in
+        /// </summary>
+        string Name { get; }
+        
+        /// <summary>
+        /// Text used in Subtitle Edit menu
+        /// </summary>
+        string Text { get; }
+        
+        /// <summary>
+        /// Version number of plugin
+        /// </summary>
+        decimal Version { get; }
+        
+        /// <summary>
+        /// Description of what plugin does
+        /// </summary>
+        string Description { get; }
+
+        /// <summary>
+        /// Can be one of these: file, tool, sync, translate, spellcheck
+        /// </summary>
+        string ActionType { get; }
+        
+        /// <summary>
+        /// Shortcut used to active plugin - e.g. Control+Shift+F9
+        /// </summary>
+        string Shortcut { get; }
+
+        /// <summary>
+        /// This action of callsed when Subtitle Edit calls plugin
+        /// </summary>
+        /// <param name="parentForm">Main form in Subtitle Edit</param>
+        /// <param name="subtitle">SubRip text</param>
+        /// <param name="frameRate">Current frame rate</param>
+        /// <param name="subtitleFileName">Current subtitle file name</param>
+        /// <param name="videoFileName">Current video file name</param>
+        /// <param name="rawText">Subtitle raw format</param>
+        /// <returns>Dialog</returns>
+        string DoAction(Form parentForm, string subtitle, double frameRate, string listViewLineSeparatorString, string subtitleFileName, string videoFileName, string rawText);
+    }
+}

--- a/source/DialogueBalancer/DLL/Logic/Configuration.cs
+++ b/source/DialogueBalancer/DLL/Logic/Configuration.cs
@@ -1,0 +1,9 @@
+﻿
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    class Configuration
+    {
+        public static double CurrentFrameRate = 30;
+        public static string ListViewLineSeparatorString = "<br />";
+    }
+}

--- a/source/DialogueBalancer/DLL/Logic/Paragraph.cs
+++ b/source/DialogueBalancer/DLL/Logic/Paragraph.cs
@@ -1,0 +1,128 @@
+﻿using System;
+
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    internal class Paragraph
+    {
+        internal int Number { get; set; }
+
+        internal string Text { get; set; }
+
+        internal TimeCode StartTime { get; set; }
+
+        internal TimeCode EndTime { get; set; }
+
+        internal TimeCode Duration
+        {
+            get
+            {
+                var timeCode = new TimeCode(EndTime.TimeSpan);
+                timeCode.AddTime(- StartTime.TotalMilliseconds);
+                return timeCode;
+            }
+        }
+
+        internal int StartFrame { get; set; }
+
+        internal int EndFrame { get; set; }
+
+        internal bool Forced { get; set; }
+
+        internal string Extra { get; set; }
+
+        internal bool IsComment { get; set; }
+
+        internal string Actor { get; set; }
+
+        internal Paragraph()
+        {
+            StartTime = new TimeCode(TimeSpan.FromSeconds(0));
+            EndTime = new TimeCode(TimeSpan.FromSeconds(0));
+            Text = string.Empty;
+        }
+
+        internal Paragraph(TimeCode startTime, TimeCode endTime, string text)
+        {
+            StartTime = startTime;
+            EndTime = endTime;
+            Text = text;
+        }
+
+        internal Paragraph(Paragraph paragraph)
+        {
+            Number = paragraph.Number;
+            Text = paragraph.Text;
+            StartTime = new TimeCode(paragraph.StartTime.TimeSpan);
+            EndTime = new TimeCode(paragraph.EndTime.TimeSpan);
+            StartFrame = paragraph.StartFrame;
+            EndFrame = paragraph.EndFrame;
+            Forced = paragraph.Forced;
+            Extra = paragraph.Extra;
+            IsComment = paragraph.IsComment;
+            Actor = paragraph.Actor;
+        }
+
+        internal Paragraph(int startFrame, int endFrame, string text)
+        {
+            StartTime = new TimeCode(0, 0, 0, 0);
+            EndTime = new TimeCode(0, 0, 0, 0);
+            StartFrame = startFrame;
+            EndFrame = endFrame;
+            Text = text;
+        }
+
+        internal Paragraph(string text, double startTotalMilliseconds, double endTotalMilliseconds)
+        {
+            StartTime = new TimeCode(TimeSpan.FromMilliseconds(startTotalMilliseconds));
+            EndTime = new TimeCode(TimeSpan.FromMilliseconds(endTotalMilliseconds));
+            Text = text;
+        }
+
+        internal void Adjust(double factor, double adjust)
+        {
+            double seconds = StartTime.TimeSpan.TotalSeconds * factor + adjust;
+            StartTime.TimeSpan = TimeSpan.FromSeconds(seconds);
+
+            seconds = EndTime.TimeSpan.TotalSeconds * factor + adjust;
+            EndTime.TimeSpan = TimeSpan.FromSeconds(seconds);
+        }
+
+        internal void CalculateFrameNumbersFromTimeCodes(double frameRate)
+        {
+            StartFrame = (int) Math.Round((StartTime.TotalMilliseconds / 1000.0 * frameRate));
+            EndFrame = (int) Math.Round((EndTime.TotalMilliseconds / 1000.0 * frameRate));
+        }
+
+        internal void CalculateTimeCodesFromFrameNumbers(double frameRate)
+        {
+           StartTime.TotalMilliseconds = StartFrame * (1000.0 / frameRate);
+           EndTime.TotalMilliseconds = EndFrame * (1000.0 / frameRate);
+        }
+
+        public override string ToString()
+        {
+            return StartTime + " --> " + EndTime + " " + Text;
+        }
+
+        internal int NumberOfLines
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(Text))
+                    return 0;
+                return Text.Length - Text.Replace(Environment.NewLine, string.Empty).Length;
+            }
+        }
+
+        internal double WordsPerMinute
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(Text))
+                    return 0;
+                int wordCount = Utilities.RemoveHtmlTags(Text).Split((" ,.!?;:()[]" + Environment.NewLine).ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Length;
+                return (60.0 / Duration.TotalSeconds) * wordCount;
+            }
+        }
+    }
+}

--- a/source/DialogueBalancer/DLL/Logic/SubRip.cs
+++ b/source/DialogueBalancer/DLL/Logic/SubRip.cs
@@ -1,0 +1,253 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    internal class SubRip : SubtitleFormat
+    {
+        internal string Errors { get; private set; }
+        private StringBuilder _errors;
+        private int _lineNumber;
+
+        enum ExpectingLine
+        {
+            Number,
+            TimeCodes,
+            Text
+        }
+
+        Paragraph _paragraph;
+        ExpectingLine _expecting = ExpectingLine.Number;
+        static Regex _regexTimeCodes = new Regex(@"^-?\d+:-?\d+:-?\d+[:,]-?\d+\s*-->\s*-?\d+:-?\d+:-?\d+[:,]-?\d+$", RegexOptions.Compiled);
+        static Regex _regexTimeCodes2 = new Regex(@"^\d+:\d+:\d+,\d+\s*-->\s*\d+:\d+:\d+,\d+$", RegexOptions.Compiled);
+
+        internal override string Extension
+        {
+            get { return ".srt"; }
+        }
+
+        internal override string Name
+        {
+            get { return "SubRip"; }
+        }
+
+        internal override bool IsTimeBased
+        {
+            get { return true; }
+        }
+
+        internal override bool IsMine(List<string> lines, string fileName)
+        {
+            var subtitle = new Subtitle();
+            LoadSubtitle(subtitle, lines, fileName);
+            return subtitle.Paragraphs.Count > _errorCount;
+        }
+
+        internal override string ToText(Subtitle subtitle, string title)
+        {
+            const string paragraphWriteFormat = "{0}\r\n{1} --> {2}\r\n{3}\r\n\r\n";
+
+            var sb = new StringBuilder();
+            foreach (Paragraph p in subtitle.Paragraphs)
+            {
+                string s = p.Text.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine).Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
+                sb.Append(string.Format(paragraphWriteFormat, p.Number, p.StartTime, p.EndTime, s));
+            }
+            return sb.ToString().Trim();
+        }
+
+        internal override void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName)
+        {
+            bool doRenum = false;
+            _errors = new StringBuilder();
+            _lineNumber = 0;
+
+            _paragraph = new Paragraph();
+            _expecting = ExpectingLine.Number;
+            _errorCount = 0;
+
+            subtitle.Paragraphs.Clear();
+            for (int i=0; i<lines.Count; i++)
+            {
+                _lineNumber++;
+                string line = lines[i].TrimEnd();
+                line = line.Trim(Convert.ToChar(127)); // 127=delete acscii
+
+                string next = string.Empty;
+                if (i + 1 < lines.Count)
+                    next = lines[i + 1];
+
+                // A new line is missing between two paragraphs (buggy srt file)
+                if (_expecting == ExpectingLine.Text && i + 1 < lines.Count &&
+                    _paragraph != null && !string.IsNullOrEmpty(_paragraph.Text) && Utilities.IsInteger(line) &&
+                    _regexTimeCodes.IsMatch(lines[i+1]))
+                {
+                    ReadLine(subtitle, string.Empty, string.Empty);
+                }
+                if (_expecting == ExpectingLine.Number && _regexTimeCodes.IsMatch(line))
+                {
+                    _expecting = ExpectingLine.TimeCodes;
+                    doRenum = true;
+                }
+
+                ReadLine(subtitle, line, next);
+            }
+            if (_paragraph.Text.Trim().Length > 0)
+                subtitle.Paragraphs.Add(_paragraph);
+
+            foreach (Paragraph p in subtitle.Paragraphs)
+                p.Text = p.Text.Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
+
+            if (doRenum)
+                subtitle.Renumber(1);
+
+            Errors = _errors.ToString();
+        }
+
+        private void ReadLine(Subtitle subtitle, string line, string next)
+        {
+            switch (_expecting)
+            {
+                case ExpectingLine.Number:
+                    if (Utilities.IsInteger(line))
+                    {
+                        _paragraph.Number = int.Parse(line);
+                        _expecting = ExpectingLine.TimeCodes;
+                    }
+                    else if (line.Trim().Length > 0)
+                    {
+                        _errorCount++;
+                    }
+                    break;
+                case ExpectingLine.TimeCodes:
+                    if (TryReadTimeCodesLine(line, _paragraph))
+                    {
+                        _paragraph.Text = string.Empty;
+                        _expecting = ExpectingLine.Text;
+                    }
+                    else if (line.Trim().Length > 0)
+                    {
+                        _errorCount++;
+                        _expecting = ExpectingLine.Number ; // lets go to next paragraph
+                    }
+                    break;
+                case ExpectingLine.Text:
+                    if (line.Trim().Length > 0)
+                    {
+                        if (_paragraph.Text.Length > 0)
+                            _paragraph.Text += Environment.NewLine;
+                        _paragraph.Text += RemoveBadChars(line).TrimEnd().Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
+                    }
+                    else if (IsText(next))
+                    {
+                        if (_paragraph.Text.Length > 0)
+                            _paragraph.Text += Environment.NewLine;
+                        _paragraph.Text += RemoveBadChars(line).TrimEnd().Replace(Environment.NewLine + Environment.NewLine, Environment.NewLine);
+                    }
+                    else if (string.IsNullOrEmpty(line) && string.IsNullOrEmpty(_paragraph.Text))
+                    {
+                        _paragraph.Text = string.Empty;
+                        if (!string.IsNullOrEmpty(next) && (Utilities.IsInteger(next) || _regexTimeCodes.IsMatch(next)))
+                        {
+                            subtitle.Paragraphs.Add(_paragraph);
+                            _paragraph = new Paragraph();
+                            _expecting = ExpectingLine.Number;
+                        }
+                    }
+                    else
+                    {
+                        subtitle.Paragraphs.Add(_paragraph);
+                        _paragraph = new Paragraph();
+                        _expecting = ExpectingLine.Number;
+                    }
+                    break;
+            }
+        }
+
+        private bool IsText(string text)
+        {
+            if (text.Trim().Length == 0)
+                return false;
+
+            if (Utilities.IsInteger(text))
+                return false;
+
+            if (_regexTimeCodes.IsMatch(text))
+                return false;
+
+            return true;
+        }
+
+        private string RemoveBadChars(string line)
+        {
+            line = line.Replace("\0", " ");
+            return line;
+        }
+
+        private bool TryReadTimeCodesLine(string line, Paragraph paragraph)
+        {
+            line = line.Replace("،", ",");
+            line = line.Replace("", ",");
+            line = line.Replace("¡", ",");
+
+            // Fix some badly formatted separator sequences - anything can happen if you manually edit ;)
+            line = line.Replace(" -> ", " --> "); // I've seen this
+            line = line.Replace(" - > ", " --> ");
+            line = line.Replace(" ->> ", " --> ");
+            line = line.Replace(" -- > ", " --> ");
+            line = line.Replace(" - -> ", " --> ");
+            line = line.Replace(" -->> ", " --> ");
+            line = line.Replace(" ---> ", " --> ");
+
+            // Removed stuff after timecodes - like subtitle position
+            //  - example of position info: 00:02:26,407 --> 00:02:31,356  X1:100 X2:100 Y1:100 Y2:100
+            if (line.Length > 30 && line[29] == ' ')
+                line = line.Substring(0, 29);
+
+            // removes all extra spaces
+            line = line.Replace(" ", string.Empty).Replace("-->", " --> ");
+            line = line.Trim();
+
+            // Fix a few more cases of wrong time codes, seen this: 00.00.02,000 --> 00.00.04,000
+            line = line.Replace('.', ':');
+            if (line.Length >= 29 && ":;".Contains(line[8].ToString()))
+                line = line.Substring(0, 8) + ',' + line.Substring(8 + 1);
+            if (line.Length >= 29 && line.Length <= 30 && ":;".Contains(line[25].ToString()))
+                line = line.Substring(0, 25) + ',' + line.Substring(25 + 1);
+
+            if (_regexTimeCodes.IsMatch(line) || _regexTimeCodes2.IsMatch(line))
+            {
+                string[] parts = line.Replace("-->", ":").Replace(" ", string.Empty).Split(':', ',');
+                try
+                {
+                    int startHours = int.Parse(parts[0]);
+                    int startMinutes = int.Parse(parts[1]);
+                    int startSeconds = int.Parse(parts[2]);
+                    int startMilliseconds = int.Parse(parts[3]);
+                    int endHours = int.Parse(parts[4]);
+                    int endMinutes = int.Parse(parts[5]);
+                    int endSeconds = int.Parse(parts[6]);
+                    int endMilliseconds = int.Parse(parts[7]);
+                    paragraph.StartTime = new TimeCode(startHours, startMinutes, startSeconds, startMilliseconds);
+                    paragraph.EndTime = new TimeCode(endHours, endMinutes, endSeconds, endMilliseconds);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        internal override List<string> AlternateExtensions
+        {
+            get
+            {
+                return new List<string> { ".wsrt" };
+            }
+        }
+    }
+}

--- a/source/DialogueBalancer/DLL/Logic/Subtitle.cs
+++ b/source/DialogueBalancer/DLL/Logic/Subtitle.cs
@@ -1,0 +1,307 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    internal class Subtitle
+    {
+        List<Paragraph> _paragraphs;
+        SubtitleFormat _format;
+        bool _wasLoadedWithFrameNumbers;
+        internal string Header { get; set; }
+        internal string Footer { get; set; }
+
+        internal string FileName { get; set; }
+
+        internal const int MaximumHistoryItems = 100;
+
+        internal SubtitleFormat OriginalFormat
+        {
+            get
+            {
+                return _format;
+            }
+        }
+
+        internal Subtitle()
+        {
+            _paragraphs = new List<Paragraph>();
+            FileName = "Untitled";
+        }
+
+        /// <summary>
+        /// Copy constructor (only paragraphs)
+        /// </summary>
+        /// <param name="subtitle">Subtitle to copy</param>
+        internal Subtitle(Subtitle subtitle)
+            : this()
+        {
+            foreach (Paragraph p in subtitle.Paragraphs)
+            {
+                _paragraphs.Add(new Paragraph(p));
+            }
+            _wasLoadedWithFrameNumbers = subtitle.WasLoadedWithFrameNumbers;
+        }
+
+        internal List<Paragraph> Paragraphs
+        {
+            get
+            {
+                return _paragraphs;
+            }
+        }
+
+        internal Paragraph GetParagraphOrDefault(int index)
+        {
+            if (_paragraphs == null || _paragraphs.Count <= index || index < 0)
+                return null;
+
+            return _paragraphs[index];
+        }
+
+            
+
+        internal string ToText(SubtitleFormat format)
+        {
+            return format.ToText(this, Path.GetFileNameWithoutExtension(FileName));
+        }
+
+        internal void AddTimeToAllParagraphs(TimeSpan time)
+        {
+            foreach (Paragraph p in Paragraphs)
+            {
+                p.StartTime.AddTime(time);
+                p.EndTime.AddTime(time);
+            }
+        }
+
+        /// <summary>
+        /// Calculate the time codes from framenumber/framerate
+        /// </summary>
+        /// <param name="frameRate">Number of frames per second</param>
+        /// <returns>True if times could be calculated</returns>
+        internal bool CalculateTimeCodesFromFrameNumbers(double frameRate)
+        {
+            if (_format == null)
+                return false;
+
+            if (_format.IsTimeBased)
+                return false;
+
+            foreach (Paragraph p in Paragraphs)
+            {
+                p.CalculateTimeCodesFromFrameNumbers(frameRate);
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Calculate the frame numbers from time codes/framerate
+        /// </summary>
+        /// <param name="frameRate"></param>
+        /// <returns></returns>
+        internal bool CalculateFrameNumbersFromTimeCodes(double frameRate)
+        {
+            if (_format == null)
+                return false;
+
+            if (_format.IsFrameBased)
+                return false;
+
+            foreach (Paragraph p in Paragraphs)
+            {
+                p.CalculateFrameNumbersFromTimeCodes(frameRate);
+            }
+
+            FixEqualOrJustOverlappingFrameNumbers();
+
+            return true;
+        }
+
+        internal void CalculateFrameNumbersFromTimeCodesNoCheck(double frameRate)
+        {
+            foreach (Paragraph p in Paragraphs)
+                p.CalculateFrameNumbersFromTimeCodes(frameRate);
+
+            FixEqualOrJustOverlappingFrameNumbers();
+        }
+
+        private void FixEqualOrJustOverlappingFrameNumbers()
+        {
+            for (int i = 0; i < Paragraphs.Count - 1; i++)
+            {
+                Paragraph p = Paragraphs[i];
+                Paragraph next = Paragraphs[i + 1];
+                if (next != null && p.EndFrame == next.StartFrame || p.EndFrame == next.StartFrame + 1)
+                    p.EndFrame = next.StartFrame - 1;
+            }
+        }
+
+        internal void ChangeFramerate(double oldFramerate, double newFramerate)
+        {
+            foreach (Paragraph p in Paragraphs)
+            {
+                double startFrame = p.StartTime.TotalMilliseconds / 1000.0 * oldFramerate;
+                double endFrame = p.EndTime.TotalMilliseconds / 1000.0 * oldFramerate;
+                p.StartTime.TotalMilliseconds = startFrame * (1000.0 / newFramerate);
+                p.EndTime.TotalMilliseconds = endFrame * (1000.0 / newFramerate);
+
+                p.CalculateFrameNumbersFromTimeCodes(newFramerate);
+            }
+        }
+
+        internal bool WasLoadedWithFrameNumbers
+        {
+            get
+            {
+                return _wasLoadedWithFrameNumbers;
+            }
+            set
+            {
+                _wasLoadedWithFrameNumbers = value;
+            }
+        }
+
+        internal void AdjustDisplayTimeUsingPercent(double percent, System.Windows.Forms.ListView.SelectedIndexCollection selectedIndexes)
+        {
+            for (int i = 0; i < _paragraphs.Count; i++)
+            {
+                if (selectedIndexes == null || selectedIndexes.Contains(i))
+                {
+                    double nextStartMilliseconds = _paragraphs[_paragraphs.Count - 1].EndTime.TotalMilliseconds + 100000;
+                    if (i + 1 < _paragraphs.Count)
+                        nextStartMilliseconds = _paragraphs[i + 1].StartTime.TotalMilliseconds;
+
+                    double newEndMilliseconds = _paragraphs[i].EndTime.TotalMilliseconds;
+                    newEndMilliseconds = _paragraphs[i].StartTime.TotalMilliseconds + (((newEndMilliseconds - _paragraphs[i].StartTime.TotalMilliseconds) * percent) / 100);
+                    if (newEndMilliseconds > nextStartMilliseconds)
+                        newEndMilliseconds = nextStartMilliseconds - 1;
+                    _paragraphs[i].EndTime.TotalMilliseconds = newEndMilliseconds;
+                }
+            }
+        }
+
+        internal void AdjustDisplayTimeUsingSeconds(double seconds, System.Windows.Forms.ListView.SelectedIndexCollection selectedIndexes)
+        {
+            for (int i = 0; i < _paragraphs.Count; i++)
+            {
+                if (selectedIndexes == null || selectedIndexes.Contains(i))
+                {
+                    double nextStartMilliseconds = _paragraphs[_paragraphs.Count - 1].EndTime.TotalMilliseconds + 100000;
+                    if (i + 1 < _paragraphs.Count)
+                        nextStartMilliseconds = _paragraphs[i + 1].StartTime.TotalMilliseconds;
+
+                    double newEndMilliseconds = _paragraphs[i].EndTime.TotalMilliseconds + (seconds * 1000.0);
+                    if (newEndMilliseconds > nextStartMilliseconds)
+                        newEndMilliseconds = nextStartMilliseconds - 1;
+
+                    if (seconds < 0)
+                    {
+                        if (_paragraphs[i].StartTime.TotalMilliseconds + 100 > newEndMilliseconds)
+                            _paragraphs[i].EndTime.TotalMilliseconds = _paragraphs[i].StartTime.TotalMilliseconds + 100;
+                        else
+                            _paragraphs[i].EndTime.TotalMilliseconds = newEndMilliseconds;
+                    }
+                    else
+                    {
+                        _paragraphs[i].EndTime.TotalMilliseconds = newEndMilliseconds;
+                    }
+                }
+            }
+        }
+
+        internal void Renumber(int startNumber)
+        {
+            int i = startNumber;
+            foreach (Paragraph p in _paragraphs)
+            {
+                p.Number = i;
+                i++;
+            }
+        }
+
+        internal int GetIndex(Paragraph p)
+        {
+            if (p == null)
+                return -1;
+
+            int index = _paragraphs.IndexOf(p);
+            if (index >= 0)
+                return index;
+
+            for (int i = 0; i < _paragraphs.Count; i++)
+            {
+                if (p.StartTime.TotalMilliseconds == _paragraphs[i].StartTime.TotalMilliseconds &&
+                    p.EndTime.TotalMilliseconds == _paragraphs[i].EndTime.TotalMilliseconds)
+                    return i;
+                if (p.Number == _paragraphs[i].Number && (p.StartTime.TotalMilliseconds == _paragraphs[i].StartTime.TotalMilliseconds ||
+                    p.EndTime.TotalMilliseconds == _paragraphs[i].EndTime.TotalMilliseconds))
+                    return i;
+                if (p.Text == _paragraphs[i].Text && (p.StartTime.TotalMilliseconds == _paragraphs[i].StartTime.TotalMilliseconds ||
+                    p.EndTime.TotalMilliseconds == _paragraphs[i].EndTime.TotalMilliseconds))
+                    return i;
+            }
+            return -1;
+        }
+
+        internal Paragraph GetFirstAlike(Paragraph p)
+        {
+            foreach (Paragraph item in _paragraphs)
+            {
+                if (p.StartTime.TotalMilliseconds == item.StartTime.TotalMilliseconds &&
+                    p.EndTime.TotalMilliseconds == item.EndTime.TotalMilliseconds &&
+                    p.Text == item.Text)
+                    return item;
+            }
+            return null;
+        }
+
+        internal Paragraph GetFirstParagraphByLineNumber(int number)
+        {
+            foreach (Paragraph p in _paragraphs)
+            {
+                if (p.Number == number)
+                    return p;
+            }
+            return null;
+        }
+
+        internal int RemoveEmptyLines()
+        {
+            int count = 0;
+            if (_paragraphs.Count > 0)
+            {
+                int firstNumber = _paragraphs[0].Number;
+                for (int i = _paragraphs.Count - 1; i >= 0; i--)
+                {
+                    Paragraph p = _paragraphs[i];
+                    string s = p.Text.Trim();
+
+                    if (s.Length == 0)
+                    {
+                        _paragraphs.RemoveAt(i);
+                        count++;
+                    }
+                }
+                Renumber(firstNumber);
+            }
+            return count;
+        }      
+
+        internal void InsertParagraphInCorrectTimeOrder(Paragraph newParagraph)
+        {
+            for (int i=0; i<Paragraphs.Count; i++)
+            {
+                Paragraph p = Paragraphs[i];
+                if (newParagraph.StartTime.TotalMilliseconds < p.StartTime.TotalMilliseconds)
+                {
+                    Paragraphs.Insert(i, newParagraph);
+                    return;
+                }
+            }
+            Paragraphs.Add(newParagraph);
+        }
+    }
+}

--- a/source/DialogueBalancer/DLL/Logic/SubtitleFormat.cs
+++ b/source/DialogueBalancer/DLL/Logic/SubtitleFormat.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    internal abstract class SubtitleFormat
+    {
+       
+        protected int _errorCount;
+
+        abstract internal string Extension
+        {
+            get;
+        }
+
+        abstract internal string Name
+        {
+            get;
+        }
+
+        abstract internal bool IsTimeBased
+        {
+            get;
+        }
+
+        internal bool IsFrameBased
+        {
+            get
+            {
+                return !IsTimeBased;
+            }
+        }
+
+        internal string FriendlyName
+        {
+            get
+            {
+                return string.Format("{0} ({1})", Name, Extension);
+            }
+        }
+
+        internal int ErrorCount
+        {
+            get { return _errorCount; }
+        }
+
+        abstract internal bool IsMine(List<string> lines, string fileName);
+
+        abstract internal string ToText(Subtitle subtitle, string title);
+
+        abstract internal void LoadSubtitle(Subtitle subtitle, List<string> lines, string fileName);
+
+        internal virtual void RemoveNativeFormatting(Subtitle subtitle)
+        {
+        }
+
+        internal virtual List<string> AlternateExtensions
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+
+        internal static int MillisecondsToFrames(double milliseconds)
+        {
+            return (int)System.Math.Round(milliseconds / (1000.0 / Configuration.CurrentFrameRate));
+        }
+
+        internal static int FramesToMilliseconds(double frames)
+        {
+            return (int)System.Math.Round(frames * (1000.0 / Configuration.CurrentFrameRate));
+        }
+
+        internal virtual bool HasStyleSupport
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+    }
+}

--- a/source/DialogueBalancer/DLL/Logic/TimeCode.cs
+++ b/source/DialogueBalancer/DLL/Logic/TimeCode.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using Nikse.SubtitleEdit.PluginLogic;
+
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    internal class TimeCode
+    {
+        TimeSpan _time;
+
+        internal static double ParseToMilliseconds(string text)
+        {
+            string[] parts = text.Split(":,.".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 4)
+            {
+                int hours;
+                int minutes;
+                int seconds;
+                int milliseconds;
+                if (int.TryParse(parts[0], out hours) && int.TryParse(parts[1], out minutes) && int.TryParse(parts[2], out seconds) && int.TryParse(parts[3], out milliseconds))
+                {
+                    TimeSpan ts = new TimeSpan(0, hours, minutes, seconds, milliseconds);
+                    return ts.TotalMilliseconds;
+                }
+            }
+            return 0;
+        }
+
+        internal static double ParseHHMMSSFFToMilliseconds(string text)
+        {
+            string[] parts = text.Split(":,.".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 4)
+            {
+                int hours;
+                int minutes;
+                int seconds;
+                int frames;
+                if (int.TryParse(parts[0], out hours) && int.TryParse(parts[1], out minutes) && int.TryParse(parts[2], out seconds) && int.TryParse(parts[3], out frames))
+                {
+                    TimeSpan ts = new TimeSpan(0, hours, minutes, seconds, SubtitleFormat.FramesToMilliseconds(frames));
+                    return ts.TotalMilliseconds;
+                }
+            }
+            return 0;
+        }
+
+        internal TimeCode(TimeSpan timeSpan)
+        {
+            TimeSpan = timeSpan;
+        }
+
+        internal TimeCode(int hour, int minute, int seconds, int milliseconds)
+        {
+            _time = new TimeSpan(0, hour, minute, seconds, milliseconds);
+        }
+
+        internal int Hours
+        {
+            get { return _time.Hours; }
+            set { _time = new TimeSpan(0, value, _time.Minutes, _time.Seconds, _time.Milliseconds); }
+        }
+
+        internal int Minutes
+        {
+            get { return _time.Minutes; }
+            set { _time = new TimeSpan(0, _time.Hours, value, _time.Seconds, _time.Milliseconds); }
+        }
+
+        internal int Seconds
+        {
+            get { return _time.Seconds; }
+            set { _time = new TimeSpan(0, _time.Hours, _time.Minutes, value, _time.Milliseconds); }
+        }
+
+        internal int Milliseconds
+        {
+            get { return _time.Milliseconds; }
+            set { _time = new TimeSpan(0, _time.Hours, _time.Minutes, _time.Seconds, value); }
+        }
+
+        internal double TotalMilliseconds
+        {
+            get { return _time.TotalMilliseconds; }
+            set { _time = TimeSpan.FromMilliseconds(value); }
+        }
+
+        internal double TotalSeconds
+        {
+            get { return _time.TotalSeconds; }
+            set { _time = TimeSpan.FromSeconds(value); }
+        }
+
+        internal TimeSpan TimeSpan
+        {
+            get
+            {
+                return _time;
+            }
+            set
+            {
+                _time = value;
+            }
+        }
+
+        internal void AddTime(int hour, int minutes, int seconds, int milliseconds)
+        {
+            Hours += hour;
+            Minutes += minutes;
+            Seconds += seconds;
+            Milliseconds += milliseconds;
+        }
+
+
+        internal void AddTime(long milliseconds)
+        {
+            _time = TimeSpan.FromMilliseconds(_time.TotalMilliseconds + milliseconds);
+        }
+
+        internal void AddTime(TimeSpan timeSpan)
+        {
+            _time = TimeSpan.FromMilliseconds(_time.TotalMilliseconds + timeSpan.TotalMilliseconds);
+        }
+
+        internal void AddTime(double milliseconds)
+        {
+            _time = TimeSpan.FromMilliseconds(_time.TotalMilliseconds + milliseconds);
+        }
+
+        public override string ToString()
+        {
+            string s = string.Format("{0:00}:{1:00}:{2:00},{3:000}", _time.Hours, _time.Minutes, _time.Seconds, _time.Milliseconds);
+
+            if (TotalMilliseconds >= 0)
+                return s;
+            else
+                return "-" + s.Replace("-", string.Empty);
+        }
+
+        internal string ToShortString()
+        {
+            string s;
+            if (_time.Minutes == 0 && _time.Hours == 0)
+                s = string.Format("{0:0},{1:000}", _time.Seconds, _time.Milliseconds);
+            else if (_time.Hours == 0)
+                s = string.Format("{0:0}:{1:00},{2:000}", _time.Minutes, _time.Seconds, _time.Milliseconds);
+            else
+                s = string.Format("{0:0}:{1:00}:{2:00},{3:000}", _time.Hours, _time.Minutes, _time.Seconds, _time.Milliseconds);
+
+            if (TotalMilliseconds >= 0)
+                return s;
+            else
+                return "-" + s.Replace("-", string.Empty);
+        }
+
+        internal string ToShortStringHHMMSSFF()
+        {
+            if (_time.Minutes == 0 && _time.Hours == 0)
+                return string.Format("{0:00}:{1:00}", _time.Seconds, SubtitleFormat.MillisecondsToFrames(_time.Milliseconds));
+            if (_time.Hours == 0)
+                return string.Format("{0:00}:{1:00}:{2:00}", _time.Minutes, _time.Seconds, SubtitleFormat.MillisecondsToFrames(_time.Milliseconds));
+            return string.Format("{0:00}:{1:00}:{2:00}:{3:00}", _time.Hours, _time.Minutes, _time.Seconds, SubtitleFormat.MillisecondsToFrames(_time.Milliseconds));
+        }
+
+        public string ToHHMMSSFF()
+        {
+            return string.Format("{0:00}:{1:00}:{2:00}:{3:00}", _time.Hours, _time.Minutes, _time.Seconds, SubtitleFormat.MillisecondsToFrames(_time.Milliseconds));
+        }
+
+        public string ToHHMMSSPeriodFF()
+        {
+            return string.Format("{0:00}:{1:00}:{2:00}.{3:00}", _time.Hours, _time.Minutes, _time.Seconds, SubtitleFormat.MillisecondsToFrames(_time.Milliseconds));
+        }
+
+    }
+}

--- a/source/DialogueBalancer/DLL/Logic/Utilities.cs
+++ b/source/DialogueBalancer/DLL/Logic/Utilities.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    public static class Utilities
+    {
+
+        public static bool IsInteger(string s)
+        {
+            int i;
+            if (int.TryParse(s, out i))
+                return true;
+            return false;
+        }
+
+        public static string RemoveHtmlTags(string s)
+        {
+            if (s == null)
+                return null;
+
+            if (!s.Contains("<"))
+                return s;
+            s = Regex.Replace(s, "(?i)</?[iub]>", string.Empty);
+            s = RemoveParagraphTag(s);
+            return RemoveHtmlFontTag(s);
+        }
+
+        internal static string RemoveHtmlFontTag(string s)
+        {
+            s = Regex.Replace(s, "(?i)</?font>", string.Empty);
+            while (s.ToLower().Contains("<font"))
+            {
+                int startIndex = s.ToLower().IndexOf("<font");
+                int endIndex = Math.Max(s.IndexOf(">"), startIndex + 4);
+                s = s.Remove(startIndex, (endIndex - startIndex) + 1);
+            }
+            return s;
+        }
+
+        internal static string RemoveParagraphTag(string s)
+        {
+            s = Regex.Replace(s, "</?p>", string.Empty);
+            while (s.ToLower().Contains("<p "))
+            {
+                int startIndex = s.ToLower().IndexOf("<p ");
+                int endIndex = Math.Max(s.IndexOf(">"), startIndex + 4);
+                s = s.Remove(startIndex, (endIndex - startIndex) + 1);
+            }
+            return s;
+        }
+
+        public static string AssemblyVersion
+        {
+            get
+            {
+                return Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            }
+        }
+
+    }
+}

--- a/source/DialogueBalancer/DLL/Plugin.cs
+++ b/source/DialogueBalancer/DLL/Plugin.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    public class DialogueBalancer : IPlugin
+    {
+        string IPlugin.Name { get { return "Dialogue Balancer"; } }
+        string IPlugin.Text { get { return "Dialogues - balance short lines..."; } }
+        decimal IPlugin.Version { get { return 1.09M; } }
+        string IPlugin.Description { get { return "Balances two-line dialogue subtitles: merges question and short reply, then re-splits evenly."; } }
+        string IPlugin.ActionType { get { return "tool"; } }
+        string IPlugin.Shortcut { get { return string.Empty; } }
+
+        string IPlugin.DoAction(Form parentForm, string subtitle, double frameRate, string listViewLineSeparatorString, string subtitleFileName, string videoFileName, string rawText)
+        {
+            subtitle = subtitle.Trim();
+            if (string.IsNullOrEmpty(subtitle))
+            {
+                MessageBox.Show("No subtitle loaded", parentForm.Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return string.Empty;
+            }
+
+            Configuration.CurrentFrameRate = frameRate;
+
+            if (!string.IsNullOrEmpty(listViewLineSeparatorString))
+                Configuration.ListViewLineSeparatorString = listViewLineSeparatorString;
+
+            var list = new List<string>();
+            foreach (string line in subtitle.Replace(Environment.NewLine, "|").Split("|".ToCharArray(), StringSplitOptions.None))
+                list.Add(line);
+
+            Subtitle sub = new Subtitle();
+            SubRip srt = new SubRip();
+            srt.LoadSubtitle(sub, list, subtitleFileName);
+
+            using (var form = new PluginForm(sub, (this as IPlugin).Name, (this as IPlugin).Description))
+            {
+                if (form.ShowDialog(parentForm) == DialogResult.OK)
+                    return form.FixedSubtitle;
+            }
+            return string.Empty;
+        }
+    }
+}

--- a/source/DialogueBalancer/DLL/PluginForm.Designer.cs
+++ b/source/DialogueBalancer/DLL/PluginForm.Designer.cs
@@ -1,0 +1,164 @@
+﻿namespace Nikse.SubtitleEdit.PluginLogic
+{
+    partial class PluginForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.buttonOK = new System.Windows.Forms.Button();
+            this.button1 = new System.Windows.Forms.Button();
+            this.labelDescription = new System.Windows.Forms.Label();
+            this.listViewFixes = new System.Windows.Forms.ListView();
+            this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader5 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader7 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.labelTotal = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // buttonOK
+            // 
+            this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonOK.Location = new System.Drawing.Point(795, 454);
+            this.buttonOK.Name = "buttonOK";
+            this.buttonOK.Size = new System.Drawing.Size(75, 23);
+            this.buttonOK.TabIndex = 0;
+            this.buttonOK.Text = "&OK";
+            this.buttonOK.UseVisualStyleBackColor = true;
+            this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);
+            // 
+            // button1
+            // 
+            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.button1.Location = new System.Drawing.Point(876, 454);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.TabIndex = 1;
+            this.button1.Text = "C&ancel";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.buttonCancel_Click);
+            // 
+            // labelDescription
+            // 
+            this.labelDescription.AutoSize = true;
+            this.labelDescription.Location = new System.Drawing.Point(13, 13);
+            this.labelDescription.Name = "labelDescription";
+            this.labelDescription.Size = new System.Drawing.Size(82, 13);
+            this.labelDescription.TabIndex = 2;
+            this.labelDescription.Text = "labelDescription";
+            // 
+            // listViewFixes
+            // 
+            this.listViewFixes.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.listViewFixes.CheckBoxes = true;
+            this.listViewFixes.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.columnHeader4,
+            this.columnHeader5,
+            this.columnHeader6,
+            this.columnHeader7,
+            this.columnHeader8});
+            this.listViewFixes.FullRowSelect = true;
+            this.listViewFixes.GridLines = true;
+            this.listViewFixes.HideSelection = false;
+            this.listViewFixes.Location = new System.Drawing.Point(12, 29);
+            this.listViewFixes.Name = "listViewFixes";
+            this.listViewFixes.Size = new System.Drawing.Size(939, 419);
+            this.listViewFixes.TabIndex = 101;
+            this.listViewFixes.UseCompatibleStateImageBehavior = false;
+            this.listViewFixes.View = System.Windows.Forms.View.Details;
+            // 
+            // columnHeader4
+            // 
+            this.columnHeader4.Text = "Apply";
+            this.columnHeader4.Width = 38;
+            // 
+            // columnHeader5
+            // 
+            this.columnHeader5.Text = "Line#";
+            this.columnHeader5.Width = 50;
+            // 
+            // columnHeader6
+            // 
+            this.columnHeader6.Text = "Function";
+            this.columnHeader6.Width = 169;
+            // 
+            // columnHeader7
+            // 
+            this.columnHeader7.Text = "Before";
+            this.columnHeader7.Width = 340;
+            // 
+            // columnHeader8
+            // 
+            this.columnHeader8.Text = "After";
+            this.columnHeader8.Width = 318;
+            // 
+            // labelTotal
+            // 
+            this.labelTotal.AutoSize = true;
+            this.labelTotal.Location = new System.Drawing.Point(9, 451);
+            this.labelTotal.Name = "labelTotal";
+            this.labelTotal.Size = new System.Drawing.Size(34, 13);
+            this.labelTotal.TabIndex = 102;
+            this.labelTotal.Text = "Total:";
+            // 
+            // PluginForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(963, 489);
+            this.Controls.Add(this.labelTotal);
+            this.Controls.Add(this.listViewFixes);
+            this.Controls.Add(this.labelDescription);
+            this.Controls.Add(this.button1);
+            this.Controls.Add(this.buttonOK);
+            this.KeyPreview = true;
+            this.Name = "PluginForm";
+            this.ShowIcon = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "PluginForm";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button buttonOK;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Label labelDescription;
+        private System.Windows.Forms.ListView listViewFixes;
+        private System.Windows.Forms.ColumnHeader columnHeader4;
+        private System.Windows.Forms.ColumnHeader columnHeader5;
+        private System.Windows.Forms.ColumnHeader columnHeader6;
+        private System.Windows.Forms.ColumnHeader columnHeader7;
+        private System.Windows.Forms.ColumnHeader columnHeader8;
+        private System.Windows.Forms.Label labelTotal;
+
+    }
+}

--- a/source/DialogueBalancer/DLL/PluginForm.cs
+++ b/source/DialogueBalancer/DLL/PluginForm.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Nikse.SubtitleEdit.PluginLogic
+{
+    internal partial class PluginForm : Form
+    {
+        internal string FixedSubtitle { get; private set; }
+        private Subtitle _subtitle;
+        private int _totalFixes = 0;
+        private bool _allowFixes = false;
+
+        private NumericUpDown _numericUpDownThreshold;
+        private Label _labelThreshold;
+
+        internal PluginForm(Subtitle subtitle, string name, string description)
+        {
+            InitializeComponent();
+
+            labelTotal.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+
+            this.Text = name;
+            labelDescription.Text = description;
+            _subtitle = subtitle;
+
+            this.Resize += (s, e) =>
+            {
+                if (listViewFixes.Columns.Count > 0)
+                    listViewFixes.Columns[listViewFixes.Columns.Count - 1].Width = -2;
+            };
+
+            _labelThreshold = new Label();
+            _labelThreshold.Text = "Fix if line difference exceeds:";
+            _labelThreshold.AutoSize = true;
+            _labelThreshold.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+
+            _numericUpDownThreshold = new NumericUpDown();
+            _numericUpDownThreshold.Size = new Size(50, 20);
+            _numericUpDownThreshold.Minimum = 0;
+            _numericUpDownThreshold.Maximum = 150;
+            _numericUpDownThreshold.Value = 22;
+            _numericUpDownThreshold.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+
+            LoadSettings();
+
+            _numericUpDownThreshold.ValueChanged += (s, e) =>
+            {
+                SaveSettings();
+                if (_allowFixes) return;
+                FindDialogueAndListFixes();
+            };
+
+            this.Controls.Add(_labelThreshold);
+            this.Controls.Add(_numericUpDownThreshold);
+
+            this.Load += (s, e) =>
+            {
+                _labelThreshold.Location = new Point(130, labelTotal.Location.Y);
+                _numericUpDownThreshold.Location = new Point(380, labelTotal.Location.Y - 2);
+            };
+
+            FindDialogueAndListFixes();
+        }
+
+        private string GetSettingsFileName()
+        {
+            string path = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Subtitle Edit", "Plugins");
+            if (!System.IO.Directory.Exists(path))
+            {
+                try
+                {
+                    System.IO.Directory.CreateDirectory(path);
+                }
+                catch { }
+            }
+            return System.IO.Path.Combine(path, "DialogueBalancer.xml");
+        }
+
+        private void LoadSettings()
+        {
+            try
+            {
+                string fileName = GetSettingsFileName();
+                if (System.IO.File.Exists(fileName))
+                {
+                    System.Xml.XmlDocument doc = new System.Xml.XmlDocument();
+                    doc.Load(fileName);
+                    System.Xml.XmlNode node = doc.DocumentElement.SelectSingleNode("Threshold");
+                    if (node != null)
+                    {
+                        int threshold;
+                        if (int.TryParse(node.InnerText, out threshold))
+                        {
+                            if (threshold >= _numericUpDownThreshold.Minimum && threshold <= _numericUpDownThreshold.Maximum)
+                                _numericUpDownThreshold.Value = threshold;
+                        }
+                    }
+                }
+            }
+            catch { }
+        }
+
+        private void SaveSettings()
+        {
+            try
+            {
+                string fileName = GetSettingsFileName();
+                System.Xml.XmlDocument doc = new System.Xml.XmlDocument();
+                doc.LoadXml("<DialogueBalancerSettings><Threshold>" + _numericUpDownThreshold.Value.ToString() + "</Threshold></DialogueBalancerSettings>");
+                doc.Save(fileName);
+            }
+            catch { }
+        }
+
+        private void buttonOK_Click(object sender, EventArgs e)
+        {
+            SaveSettings();
+            _allowFixes = true;
+            FindDialogueAndListFixes();
+            FixedSubtitle = _subtitle.ToText(new SubRip());
+            DialogResult = DialogResult.OK;
+        }
+
+        private void buttonCancel_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+        }
+
+        private void AddFixToListView(Paragraph p, string action, string before, string after)
+        {
+            var item = new ListViewItem(string.Empty) { Checked = true };
+
+            var subItem = new ListViewItem.ListViewSubItem(item, p.Number.ToString());
+            item.SubItems.Add(subItem);
+            subItem = new ListViewItem.ListViewSubItem(item, action);
+            item.SubItems.Add(subItem);
+            subItem = new ListViewItem.ListViewSubItem(item, before.Replace(Environment.NewLine, Configuration.ListViewLineSeparatorString));
+            item.SubItems.Add(subItem);
+            subItem = new ListViewItem.ListViewSubItem(item, after.Replace(Environment.NewLine, Configuration.ListViewLineSeparatorString));
+            item.SubItems.Add(subItem);
+
+            item.Tag = p;
+
+            listViewFixes.Items.Add(item);
+        }
+
+        private void FindDialogueAndListFixes()
+        {
+            string fixAction = "Balance dialogue";
+
+            if (!_allowFixes)
+            {
+                _totalFixes = 0;
+                listViewFixes.BeginUpdate();
+                listViewFixes.Items.Clear();
+            }
+
+            for (int i = 0; i < _subtitle.Paragraphs.Count; i++)
+            {
+                Paragraph p = _subtitle.Paragraphs[i];
+                string text = p.Text;
+                string newText = BalanceDialogue(text);
+
+                if (text != newText)
+                {
+                    if (AllowFix(p, fixAction))
+                    {
+                        p.Text = newText;
+                    }
+                    else if (!_allowFixes)
+                    {
+                        _totalFixes++;
+                        string oldTextPreview = Utilities.RemoveHtmlTags(text);
+                        string newTextPreview = Utilities.RemoveHtmlTags(newText);
+                        AddFixToListView(p, fixAction, oldTextPreview, newTextPreview);
+                    }
+                }
+            }
+
+            if (!_allowFixes)
+            {
+                labelTotal.Text = "Total: " + _totalFixes.ToString();
+                labelTotal.ForeColor = _totalFixes > 0 ? Color.Blue : Color.Red;
+                listViewFixes.EndUpdate();
+            }
+        }
+
+        private bool AllowFix(Paragraph p, string action)
+        {
+            if (!_allowFixes)
+                return false;
+
+            string ln = p.Number.ToString();
+            foreach (ListViewItem item in listViewFixes.Items)
+            {
+                if (item.SubItems.Count > 2 && item.SubItems[1].Text == ln && item.SubItems[2].Text == action)
+                    return item.Checked;
+            }
+            return false;
+        }
+
+        private string BalanceDialogue(string text)
+        {
+            string[] lines = text.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+
+            if (lines.Length != 2) return text;
+
+            string line1 = lines[0].Trim();
+            string line2 = lines[1].Trim();
+
+            string cleanLine1 = Utilities.RemoveHtmlTags(line1);
+            string cleanLine2 = Utilities.RemoveHtmlTags(line2);
+
+            if (cleanLine1.StartsWith("-") || !cleanLine2.StartsWith("-"))
+                return text;
+
+            int threshold = (int)_numericUpDownThreshold.Value;
+            int line1Length = cleanLine1.Length;
+            int line2Length = cleanLine2.TrimStart('-').Trim().Length;
+
+            if (Math.Abs(line1Length - line2Length) < threshold)
+                return text;
+
+            string merged = line1 + " - " + line2.TrimStart('-').Trim();
+
+            int middle = merged.Length / 2;
+            int bestSpace = -1;
+            int minDistance = merged.Length;
+
+            for (int i = 0; i < merged.Length; i++)
+            {
+                if (merged[i] == ' ')
+                {
+                    string leftSide = merged.Substring(0, i).Trim();
+                    if (leftSide.EndsWith(" -") || leftSide == "-")
+                        continue;
+
+                    int distance = Math.Abs(i - middle);
+                    if (distance < minDistance)
+                    {
+                        minDistance = distance;
+                        bestSpace = i;
+                    }
+                }
+            }
+
+            if (bestSpace != -1)
+            {
+                return merged.Substring(0, bestSpace).Trim()
+                     + Environment.NewLine
+                     + merged.Substring(bestSpace + 1).Trim();
+            }
+
+            return text;
+        }
+    }
+}

--- a/source/DialogueBalancer/DLL/PluginForm.resx
+++ b/source/DialogueBalancer/DLL/PluginForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/source/DialogueBalancer/DLL/Properties/AssemblyInfo.cs
+++ b/source/DialogueBalancer/DLL/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("DialogueBalancer")]
+[assembly: AssemblyDescription("Balances short dialogue lines")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Gemini 3 Pro + Claude Sonnet 4.6 Thinking")]
+[assembly: AssemblyProduct("DialogueBalancer")]
+[assembly: AssemblyCopyright("Copyright © 2026 - License: MIT")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+[assembly: Guid("8A9B25A7-8869-450F-87C2-113AD0ADDEE7")]
+[assembly: AssemblyVersion("1.0.9")]
+[assembly: AssemblyFileVersion("1.0.9")]


### PR DESCRIPTION
This plugin automatically balances two-line dialogue subtitles when the visual difference between lines exceeds a user-defined threshold. It follows Channel 4 and BBC guidelines for visual balance and includes orphaned hyphen prevention.