### PR TITLE
Add Subtitle Edit 5 plugin index and Haxor sample plugin

### DIFF
--- a/se5-plugins.json
+++ b/se5-plugins.json
@@ -1,0 +1,14 @@
+{
+  "plugins": [
+    {
+      "name": "Haxor",
+      "description": "Translates the text of the selected lines (or all lines) to haxor.",
+      "version": "1.0.0",
+      "author": "Subtitle Edit",
+      "url": "https://github.com/SubtitleEdit/plugins/tree/master/se5/Haxor",
+      "date": "2026-05-14",
+      "minSeVersion": "5.0.0",
+      "downloadUrl": "https://github.com/SubtitleEdit/plugins/releases/download/se5-v1.0/Haxor.zip"
+    }
+  ]
+}

--- a/se5/Haxor/Haxor.csproj
+++ b/se5/Haxor/Haxor.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>Haxor</AssemblyName>
+    <RootNamespace>SubtitleEdit.Plugins.Haxor</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+</Project>

--- a/se5/Haxor/HaxorTranslator.cs
+++ b/se5/Haxor/HaxorTranslator.cs
@@ -1,0 +1,35 @@
+using System.Text;
+
+namespace SubtitleEdit.Plugins.Haxor;
+
+/// <summary>Lower-cases text and swaps a handful of letters for their "haxor" look-alikes.</summary>
+public static class HaxorTranslator
+{
+    private static readonly Dictionary<char, char> Map = new()
+    {
+        ['a'] = '4',
+        ['c'] = '©',
+        ['e'] = '3',
+        ['h'] = 'H',
+        ['i'] = '!',
+        ['k'] = 'K',
+        ['n'] = 'ñ',
+        ['o'] = '0',
+        ['s'] = '$',
+        ['y'] = '¥',
+    };
+
+    public static string Translate(string text)
+    {
+        var sb = new StringBuilder(text.ToLowerInvariant());
+        for (var i = 0; i < sb.Length; i++)
+        {
+            if (Map.TryGetValue(sb[i], out var mapped))
+            {
+                sb[i] = mapped;
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/se5/Haxor/PluginContract.cs
+++ b/se5/Haxor/PluginContract.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+
+namespace SubtitleEdit.Plugins.Haxor;
+
+// These types mirror the Subtitle Edit 5 plugin JSON contract.
+// See https://github.com/SubtitleEdit/subtitleedit/blob/main/docs/plugin.md
+
+/// <summary>Written by Subtitle Edit; its path is passed as the first command-line argument.</summary>
+public sealed class PluginRequest
+{
+    public int ApiVersion { get; set; } = 1;
+    public string RequestType { get; set; } = "run";
+
+    /// <summary>Where this plugin must write its <see cref="PluginResponse"/>.</summary>
+    public string ResponseFilePath { get; set; } = string.Empty;
+
+    /// <summary>A scratch directory; deleted by Subtitle Edit after the run.</summary>
+    public string TempDirectory { get; set; } = string.Empty;
+
+    public PluginSubtitle Subtitle { get; set; } = new();
+
+    /// <summary>Zero-based indices of the lines selected in the grid (empty if none).</summary>
+    public List<int> SelectedIndices { get; set; } = new();
+
+    public string VideoFileName { get; set; } = string.Empty;
+    public double FrameRate { get; set; }
+    public string UiLanguage { get; set; } = string.Empty;
+    public string Theme { get; set; } = string.Empty;
+    public string SeVersion { get; set; } = string.Empty;
+
+    /// <summary>This plugin's settings as last persisted by Subtitle Edit (null on first run).</summary>
+    public JsonElement? Settings { get; set; }
+}
+
+public sealed class PluginSubtitle
+{
+    /// <summary>Friendly format name, e.g. "SubRip".</summary>
+    public string Format { get; set; } = string.Empty;
+
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>Full subtitle text in <see cref="Format"/>.</summary>
+    public string Native { get; set; } = string.Empty;
+
+    /// <summary>Full subtitle text as SubRip (.srt) - always provided in requests.</summary>
+    public string SubRip { get; set; } = string.Empty;
+}
+
+/// <summary>Written by this plugin to <see cref="PluginRequest.ResponseFilePath"/>.</summary>
+public sealed class PluginResponse
+{
+    public int ApiVersion { get; set; } = 1;
+
+    /// <summary>"ok": apply the subtitle; "cancelled": do nothing; "error": show the message.</summary>
+    public string Status { get; set; } = "cancelled";
+
+    public string? Message { get; set; }
+
+    /// <summary>The modified subtitle. Only <see cref="PluginSubtitle.Format"/> and <see cref="PluginSubtitle.Native"/> are read.</summary>
+    public PluginSubtitle? Subtitle { get; set; }
+
+    /// <summary>Settings to persist; handed back unchanged in the next request.</summary>
+    public JsonElement? Settings { get; set; }
+
+    public string? UndoDescription { get; set; }
+}

--- a/se5/Haxor/Program.cs
+++ b/se5/Haxor/Program.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using SubtitleEdit.Plugins.Haxor;
+
+// A Subtitle Edit 5 plugin is just an executable:
+//   1. read the request file (its path is the first command-line argument),
+//   2. transform the subtitle,
+//   3. write the response file (path is given in the request),
+//   4. exit with code 0.
+
+if (args.Length < 1)
+{
+    Console.Error.WriteLine("Usage: Haxor <requestFilePath>");
+    return 1;
+}
+
+var jsonOptions = new JsonSerializerOptions
+{
+    PropertyNameCaseInsensitive = true,
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    WriteIndented = true,
+};
+
+PluginRequest? request;
+try
+{
+    request = JsonSerializer.Deserialize<PluginRequest>(File.ReadAllText(args[0]), jsonOptions);
+}
+catch (Exception exception)
+{
+    Console.Error.WriteLine("Could not read request: " + exception.Message);
+    return 1;
+}
+
+if (request is null || string.IsNullOrEmpty(request.ResponseFilePath))
+{
+    Console.Error.WriteLine("Invalid request.");
+    return 1;
+}
+
+// Work on the SubRip representation - it is always provided in the request.
+var srt = request.Subtitle.SubRip;
+var selected = new HashSet<int>(request.SelectedIndices);
+
+var count = 0;
+var blocks = Regex.Split(srt.Replace("\r\n", "\n").Trim('\n'), @"\n[ \t]*\n");
+for (var i = 0; i < blocks.Length; i++)
+{
+    // An empty SelectedIndices means "apply to every line".
+    if (selected.Count > 0 && !selected.Contains(i))
+    {
+        continue;
+    }
+
+    // A SubRip block is: number line, timecode line, then one or more text lines.
+    var lines = blocks[i].Split('\n');
+    if (lines.Length < 3)
+    {
+        continue;
+    }
+
+    for (var t = 2; t < lines.Length; t++)
+    {
+        lines[t] = HaxorTranslator.Translate(lines[t]);
+    }
+
+    blocks[i] = string.Join('\n', lines);
+    count++;
+}
+
+var response = new PluginResponse
+{
+    Status = "ok",
+    Message = count == 0 ? "No lines changed." : $"Translated {count} line(s) to haxor.",
+    UndoDescription = "Haxor 1.0.0",
+    Subtitle = new PluginSubtitle
+    {
+        Format = "SubRip",
+        Native = (string.Join("\n\n", blocks) + "\n").Replace("\n", "\r\n"),
+    },
+};
+
+File.WriteAllText(request.ResponseFilePath, JsonSerializer.Serialize(response, jsonOptions));
+return 0;

--- a/se5/Haxor/README.md
+++ b/se5/Haxor/README.md
@@ -1,0 +1,49 @@
+# Haxor (Subtitle Edit 5 sample plugin)
+
+Translates subtitle text to "haxor" — lower-cases it and swaps a few letters for
+look-alikes (`a→4`, `e→3`, `o→0`, `s→$`, `i→!`, `c→©`, `h→H`, `k→K`, `n→ñ`, `y→¥`).
+If lines are selected in the grid only those are changed, otherwise every line is.
+
+This is a reference plugin for the Subtitle Edit 5 plugin system. It shows the whole
+contract: read the request JSON, transform the subtitle, write the response JSON.
+See [docs/plugin.md](https://github.com/SubtitleEdit/subtitleedit/blob/main/docs/plugin.md)
+for the full specification.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `plugin.json` | Manifest — lets Subtitle Edit list the plugin without launching it. |
+| `PluginContract.cs` | The request/response DTOs (the JSON contract). |
+| `Program.cs` | Entry point: read request → transform → write response → exit 0. |
+| `HaxorTranslator.cs` | The actual text transformation. |
+
+## Build
+
+```
+dotnet publish Haxor.csproj -c Release -o publish
+```
+
+## Install for testing
+
+Copy the build output plus `plugin.json` into a folder under Subtitle Edit's
+`Plugins` directory:
+
+```
+Plugins/
+  Haxor/
+    plugin.json
+    Haxor.dll
+    Haxor.runtimeconfig.json
+    ... (other files from publish/)
+```
+
+The manifest uses `"runtime": "dotnet"`, so Subtitle Edit launches it as
+`dotnet Haxor.dll <requestFile>` — the .NET 8 runtime must be installed. To ship a
+self-contained build instead, publish with `-r <rid> --self-contained` and replace
+the `runtime`/`entry` fields in `plugin.json` with an `executables` block.
+
+## Package for the plugin index
+
+Zip the plugin folder (so the zip contains a single top-level `Haxor/` folder),
+attach it to a GitHub release, and point `downloadUrl` in `se5-plugins.json` at it.

--- a/se5/Haxor/plugin.json
+++ b/se5/Haxor/plugin.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": 1,
+  "name": "Haxor",
+  "description": "Translates the text of the selected lines (or all lines) to haxor.",
+  "version": "1.0.0",
+  "author": "Subtitle Edit",
+  "url": "https://github.com/SubtitleEdit/plugins/tree/master/se5/Haxor",
+  "menu": "Translate",
+  "minSeVersion": "5.0.0",
+  "runtime": "dotnet",
+  "entry": "Haxor.dll"
+}


### PR DESCRIPTION
## Summary

Adds the Subtitle Edit 5 plugin index and a sample plugin. SE5's plugin system ([subtitleedit#10912](https://github.com/SubtitleEdit/subtitleedit/pull/10912)) loads plugins as standalone executables that exchange JSON files with Subtitle Edit — a clean break from the SE4 in-process WinForms DLLs, which can't run on the cross-platform Avalonia build.

- **`se5-plugins.json`** — the download index read by SE5's *Get plugins online...* feature. `PluginConstants.OnlineIndexUrl` points at this file on `main`.
- **`se5/Haxor/`** — a sample SE5 plugin (under a new `se5/` folder to keep it separate from the SE4 plugins). It translates subtitle text to "haxor" (lower-case + look-alike swaps: `a→4 e→3 o→0 s→$ i→! c→© h→H k→K n→ñ y→¥`), honoring the grid selection. It doubles as a reference implementation of the SE5 plugin contract:
  - `plugin.json` — manifest
  - `PluginContract.cs` — request/response DTOs
  - `Program.cs` — read request → transform → write response → exit 0
  - `HaxorTranslator.cs` — the transform
  - `README.md` — build/install/packaging instructions

## Notes

- The index `downloadUrl` points at a `se5-v1.0` release that does not exist yet — a `Haxor.zip` (the published plugin folder, zipped) must be attached to a GitHub release before the in-app installer can fetch it.
- Builds clean with `dotnet build` (net8.0); verified end-to-end against a sample request.

## Test plan

- [ ] `dotnet publish se5/Haxor/Haxor.csproj -c Release`, zip the output + `plugin.json`, attach to a `se5-v1.0` release.
- [ ] In SE5: **Plugins → Manage plugins... → Get plugins online...**, install Haxor, confirm it appears in the Translate area and transforms selected lines.