### PR TITLE
Fix Typewriter plugin startup crash (NRE on named controls)

### DIFF
--- a/.github/workflows/typewriter.yml
+++ b/.github/workflows/typewriter.yml
@@ -59,8 +59,8 @@ jobs:
             -c Release \
             -r ${{ matrix.rid }} \
             --self-contained true \
-            -p:PublishSingleFile=true \
-            -p:IncludeNativeLibrariesForSelfExtract=true \
+            -p:DebugType=None \
+            -p:DebugSymbols=false \
             -o staging/TypewriterEffect
 
       - name: Rewrite plugin.json for ${{ matrix.os }}

--- a/se5-plugins.json
+++ b/se5-plugins.json
@@ -3,18 +3,18 @@
     {
       "name": "Typewriter effect",
       "description": "Splits each subtitle line into short timed parts that progressively reveal the text, character by character.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": "Subtitle Edit",
       "url": "https://github.com/SubtitleEdit/plugins/tree/main/se5/TypewriterEffect",
       "date": "2026-05-17",
       "minSeVersion": "5.0.0",
       "downloads": {
-        "win-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0/TypewriterEffect-win-x64.zip",
-        "win-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0/TypewriterEffect-win-arm64.zip",
-        "linux-x64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0/TypewriterEffect-linux-x64.zip",
-        "linux-arm64": "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0/TypewriterEffect-linux-arm64.zip",
-        "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0/TypewriterEffect-osx-x64.zip",
-        "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0/TypewriterEffect-osx-arm64.zip"
+        "win-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-win-x64.zip",
+        "win-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-win-arm64.zip",
+        "linux-x64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-linux-x64.zip",
+        "linux-arm64": "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-linux-arm64.zip",
+        "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-osx-x64.zip",
+        "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-osx-arm64.zip"
       }
     },
     {

--- a/se5/TypewriterEffect/MainWindow.axaml.cs
+++ b/se5/TypewriterEffect/MainWindow.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using System;
+using System.Globalization;
 using System.Text.Json;
 
 namespace SubtitleEdit.Plugins.TypewriterEffect;
@@ -9,24 +10,31 @@ namespace SubtitleEdit.Plugins.TypewriterEffect;
 public partial class MainWindow : Window
 {
     private readonly PluginRequest _request;
+    private TextBlock _infoLabel = null!;
+    private NumericUpDown _endDelayInput = null!;
 
     // Parameterless constructor only exists for the XAML designer.
     public MainWindow() : this(new PluginRequest()) { }
 
     public MainWindow(PluginRequest request)
     {
-        InitializeComponent();
         _request = request;
+        InitializeComponent();
 
         var selectedCount = request.SelectedIndices.Count;
-        InfoLabel.Text = selectedCount > 0
+        _infoLabel.Text = selectedCount > 0
             ? $"Each of the {selectedCount} selected line(s) will be split into several short lines that progressively reveal the text."
             : "Every line will be split into several short lines that progressively reveal the text.";
 
-        EndDelayInput.Value = (decimal)LoadEndDelaySetting(request.Settings, defaultValue: 0.5);
+        _endDelayInput.Value = (decimal)LoadEndDelaySetting(request.Settings, defaultValue: 0.5);
     }
 
-    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+        _infoLabel = this.FindControl<TextBlock>("InfoLabel")!;
+        _endDelayInput = this.FindControl<NumericUpDown>("EndDelayInput")!;
+    }
 
     private void OnCancel(object? sender, RoutedEventArgs e)
     {
@@ -36,7 +44,7 @@ public partial class MainWindow : Window
 
     private void OnOk(object? sender, RoutedEventArgs e)
     {
-        var endDelaySec = (double)(EndDelayInput.Value ?? 0m);
+        var endDelaySec = (double)(_endDelayInput.Value ?? 0m);
 
         try
         {
@@ -84,7 +92,8 @@ public partial class MainWindow : Window
 
     private static JsonElement BuildSettings(double endDelay)
     {
-        using var doc = JsonDocument.Parse($"{{\"endDelay\":{endDelay.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)}}}");
+        var json = $"{{\"endDelay\":{endDelay.ToString("0.###", CultureInfo.InvariantCulture)}}}";
+        using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
     }
 }

--- a/se5/TypewriterEffect/plugin.json
+++ b/se5/TypewriterEffect/plugin.json
@@ -2,7 +2,7 @@
   "apiVersion": 1,
   "name": "Typewriter effect",
   "description": "Splits each subtitle line into short timed parts that progressively reveal the text, character by character.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Subtitle Edit",
   "url": "https://github.com/SubtitleEdit/plugins/tree/main/se5/TypewriterEffect",
   "menu": "Tools",


### PR DESCRIPTION
## Summary
Fixes the v1.0 Typewriter plugin aborting with exit code 134 right after launch.

### Root cause
\`MainWindow\` accessed \`InfoLabel\` / \`EndDelayInput\` / \`OkButton\` as if they were auto-assigned fields. Avalonia 11 does **not** generate fields for \`x:Name\` elements out of the box (that requires the \`Avalonia.NameGenerator\` package), so every access threw \`NullReferenceException\` right after \`AvaloniaXamlLoader.Load(this)\` returned. The unhandled exception aborted the process with SIGABRT — what the host saw as \`exited with code 134\`.

Resolved by looking the controls up via \`FindControl\` in \`InitializeComponent\` and caching them as fields. Verified locally by publishing osx-arm64 and launching with a fake request — window stays up cleanly.

### Bonus fixes
- Dropped \`PublishSingleFile=true\` / \`IncludeNativeLibrariesForSelfExtract=true\` from \`typewriter.yml\`. Avalonia's recommended deployment is multi-file self-contained — single-file extraction is a known source of native-load surprises. Zip sizes don't grow much.
- Bumped \`plugin.json\` version to \`1.0.1\` and pointed \`se5-plugins.json\` at the new \`se5-typewriter-v1.0.1\` release tag so anyone who installed the broken 1.0 sees *Update available*.

## Test plan
- [ ] CI matrix build passes on all six RIDs.
- [ ] Manually dispatch the workflow with tag \`se5-typewriter-v1.0.1\` after merge to publish the fixed zips.
- [ ] In SE: **Get plugins online...** shows *Update available (1.0.0 → 1.0.1)* — install — run the plugin and verify the window opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)