### PR TITLE
Bring Typewriter plugin window to foreground on launch

### DIFF
--- a/se5-plugins.json
+++ b/se5-plugins.json
@@ -3,18 +3,18 @@
     {
       "name": "Typewriter effect",
       "description": "Splits each subtitle line into short timed parts that progressively reveal the text, character by character.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": "Subtitle Edit",
       "url": "https://github.com/SubtitleEdit/plugins/tree/main/se5/TypewriterEffect",
       "date": "2026-05-17",
       "minSeVersion": "5.0.0",
       "downloads": {
-        "win-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-win-x64.zip",
-        "win-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-win-arm64.zip",
-        "linux-x64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-linux-x64.zip",
-        "linux-arm64": "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-linux-arm64.zip",
-        "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-osx-x64.zip",
-        "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.1/TypewriterEffect-osx-arm64.zip"
+        "win-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.2/TypewriterEffect-win-x64.zip",
+        "win-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.2/TypewriterEffect-win-arm64.zip",
+        "linux-x64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.2/TypewriterEffect-linux-x64.zip",
+        "linux-arm64": "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.2/TypewriterEffect-linux-arm64.zip",
+        "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.2/TypewriterEffect-osx-x64.zip",
+        "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-typewriter-v1.0.2/TypewriterEffect-osx-arm64.zip"
       }
     },
     {

--- a/se5/TypewriterEffect/MainWindow.axaml.cs
+++ b/se5/TypewriterEffect/MainWindow.axaml.cs
@@ -36,6 +36,19 @@ public partial class MainWindow : Window
         _endDelayInput = this.FindControl<NumericUpDown>("EndDelayInput")!;
     }
 
+    protected override void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+
+        // The plugin is a fresh process with no parent window relationship to
+        // Subtitle Edit, so on macOS/Linux/sometimes Windows it can appear
+        // behind SE. Toggling Topmost briefly forces the window to the top of
+        // the z-order, and Activate() gives it focus.
+        Topmost = true;
+        Activate();
+        Topmost = false;
+    }
+
     private void OnCancel(object? sender, RoutedEventArgs e)
     {
         App.Response = new PluginResponse { Status = "cancelled" };

--- a/se5/TypewriterEffect/plugin.json
+++ b/se5/TypewriterEffect/plugin.json
@@ -2,7 +2,7 @@
   "apiVersion": 1,
   "name": "Typewriter effect",
   "description": "Splits each subtitle line into short timed parts that progressively reveal the text, character by character.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Subtitle Edit",
   "url": "https://github.com/SubtitleEdit/plugins/tree/main/se5/TypewriterEffect",
   "menu": "Tools",


### PR DESCRIPTION
## Summary
- Plugin process has no parent window relationship to Subtitle Edit, so on macOS (and sometimes Windows/Linux) the dialog opened behind SE and looked like nothing happened.
- Override \`OnOpened\` to briefly set \`Topmost = true\`, call \`Activate()\`, then drop \`Topmost\` back to \`false\`. The window jumps to the top of the z-order with focus, and the user can still place other windows over it afterwards.
- Bumped to 1.0.2 and pointed \`se5-plugins.json\` at \`se5-typewriter-v1.0.2\` so anyone with 1.0.1 installed sees *Update available*.

## Test plan
- [ ] Install 1.0.2 — invoke from SE — window appears in front of SE.