### PR TITLE
Theme support, centered buttons, and auto-bump release workflows for SE5 plugins

### DIFF
--- a/.github/workflows/american-to-british.yml
+++ b/.github/workflows/american-to-british.yml
@@ -14,13 +14,71 @@ on:
       - '.github/workflows/american-to-british.yml'
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Release tag to publish the zips under (e.g. se5-american-to-british-v1.0). Leave empty to build artifacts only.'
+      release:
+        description: 'Publish a GitHub release. Bumps the minor in plugin.json and commits it back.'
+        type: boolean
+        default: false
+      version:
+        description: 'Optional explicit version (e.g. 1.2.0). Overrides the auto-minor-bump.'
         required: false
         type: string
 
+permissions:
+  contents: write
+
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set.outputs.version }}
+      tag:     ${{ steps.set.outputs.tag }}
+      ref:     ${{ steps.set.outputs.ref }}
+      release: ${{ steps.set.outputs.release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version (and bump on release)
+        id: set
+        run: |
+          set -e
+          current=$(jq -r .version se5/AmericanToBritish/plugin.json)
+          release_flag="false"
+          ref="${{ github.sha }}"
+          version="$current"
+          tag=""
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.release }}" = "true" ]; then
+            release_flag="true"
+            if [ -n "${{ inputs.version }}" ]; then
+              version="${{ inputs.version }}"
+            else
+              IFS=. read -r major minor patch <<< "$current"
+              version="$major.$((minor + 1)).0"
+            fi
+
+            tmp=$(mktemp)
+            jq --arg v "$version" '.version = $v' se5/AmericanToBritish/plugin.json > "$tmp"
+            mv "$tmp" se5/AmericanToBritish/plugin.json
+
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add se5/AmericanToBritish/plugin.json
+            git commit -m "Bump AmericanToBritish to $version [skip ci]"
+            git push
+            ref=$(git rev-parse HEAD)
+
+            IFS=. read -r major minor patch <<< "$version"
+            tag="se5-american-to-british-v$major.$minor"
+          fi
+
+          echo "version=$version"  >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"          >> "$GITHUB_OUTPUT"
+          echo "ref=$ref"          >> "$GITHUB_OUTPUT"
+          echo "release=$release_flag" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -48,6 +106,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
@@ -85,11 +145,9 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: build
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''
+    needs: [prepare, build]
+    if: needs.prepare.outputs.release == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Download all zips
         uses: actions/download-artifact@v4
@@ -102,8 +160,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.event.inputs.tag }}" dist/AmericanToBritish-*.zip \
+          gh release create "${{ needs.prepare.outputs.tag }}" dist/AmericanToBritish-*.zip \
             --repo "${{ github.repository }}" \
-            --target "${{ github.sha }}" \
-            --title "AmericanToBritish ${{ github.event.inputs.tag }}" \
+            --target "${{ needs.prepare.outputs.ref }}" \
+            --title "AmericanToBritish v${{ needs.prepare.outputs.version }}" \
             --notes "Self-contained AmericanToBritish plugin builds for win/linux/osx (x64 + arm64)."

--- a/.github/workflows/british-to-american.yml
+++ b/.github/workflows/british-to-american.yml
@@ -14,13 +14,71 @@ on:
       - '.github/workflows/british-to-american.yml'
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Release tag to publish the zips under (e.g. se5-british-to-american-v1.0). Leave empty to build artifacts only.'
+      release:
+        description: 'Publish a GitHub release. Bumps the minor in plugin.json and commits it back.'
+        type: boolean
+        default: false
+      version:
+        description: 'Optional explicit version (e.g. 1.2.0). Overrides the auto-minor-bump.'
         required: false
         type: string
 
+permissions:
+  contents: write
+
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set.outputs.version }}
+      tag:     ${{ steps.set.outputs.tag }}
+      ref:     ${{ steps.set.outputs.ref }}
+      release: ${{ steps.set.outputs.release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version (and bump on release)
+        id: set
+        run: |
+          set -e
+          current=$(jq -r .version se5/BritishToAmerican/plugin.json)
+          release_flag="false"
+          ref="${{ github.sha }}"
+          version="$current"
+          tag=""
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.release }}" = "true" ]; then
+            release_flag="true"
+            if [ -n "${{ inputs.version }}" ]; then
+              version="${{ inputs.version }}"
+            else
+              IFS=. read -r major minor patch <<< "$current"
+              version="$major.$((minor + 1)).0"
+            fi
+
+            tmp=$(mktemp)
+            jq --arg v "$version" '.version = $v' se5/BritishToAmerican/plugin.json > "$tmp"
+            mv "$tmp" se5/BritishToAmerican/plugin.json
+
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add se5/BritishToAmerican/plugin.json
+            git commit -m "Bump BritishToAmerican to $version [skip ci]"
+            git push
+            ref=$(git rev-parse HEAD)
+
+            IFS=. read -r major minor patch <<< "$version"
+            tag="se5-british-to-american-v$major.$minor"
+          fi
+
+          echo "version=$version"  >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"          >> "$GITHUB_OUTPUT"
+          echo "ref=$ref"          >> "$GITHUB_OUTPUT"
+          echo "release=$release_flag" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -48,6 +106,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
@@ -85,11 +145,9 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: build
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''
+    needs: [prepare, build]
+    if: needs.prepare.outputs.release == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Download all zips
         uses: actions/download-artifact@v4
@@ -102,8 +160,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.event.inputs.tag }}" dist/BritishToAmerican-*.zip \
+          gh release create "${{ needs.prepare.outputs.tag }}" dist/BritishToAmerican-*.zip \
             --repo "${{ github.repository }}" \
-            --target "${{ github.sha }}" \
-            --title "BritishToAmerican ${{ github.event.inputs.tag }}" \
+            --target "${{ needs.prepare.outputs.ref }}" \
+            --title "BritishToAmerican v${{ needs.prepare.outputs.version }}" \
             --notes "Self-contained BritishToAmerican plugin builds for win/linux/osx (x64 + arm64)."

--- a/.github/workflows/haxor.yml
+++ b/.github/workflows/haxor.yml
@@ -12,13 +12,71 @@ on:
       - '.github/workflows/haxor.yml'
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Release tag to publish the zips under (e.g. se5-haxor-v1.0). Leave empty to build artifacts only.'
+      release:
+        description: 'Publish a GitHub release. Bumps the minor in plugin.json and commits it back.'
+        type: boolean
+        default: false
+      version:
+        description: 'Optional explicit version (e.g. 1.2.0). Overrides the auto-minor-bump.'
         required: false
         type: string
 
+permissions:
+  contents: write
+
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set.outputs.version }}
+      tag:     ${{ steps.set.outputs.tag }}
+      ref:     ${{ steps.set.outputs.ref }}
+      release: ${{ steps.set.outputs.release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version (and bump on release)
+        id: set
+        run: |
+          set -e
+          current=$(jq -r .version se5/Haxor/plugin.json)
+          release_flag="false"
+          ref="${{ github.sha }}"
+          version="$current"
+          tag=""
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.release }}" = "true" ]; then
+            release_flag="true"
+            if [ -n "${{ inputs.version }}" ]; then
+              version="${{ inputs.version }}"
+            else
+              IFS=. read -r major minor patch <<< "$current"
+              version="$major.$((minor + 1)).0"
+            fi
+
+            tmp=$(mktemp)
+            jq --arg v "$version" '.version = $v' se5/Haxor/plugin.json > "$tmp"
+            mv "$tmp" se5/Haxor/plugin.json
+
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add se5/Haxor/plugin.json
+            git commit -m "Bump Haxor to $version [skip ci]"
+            git push
+            ref=$(git rev-parse HEAD)
+
+            IFS=. read -r major minor patch <<< "$version"
+            tag="se5-haxor-v$major.$minor"
+          fi
+
+          echo "version=$version"  >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"          >> "$GITHUB_OUTPUT"
+          echo "ref=$ref"          >> "$GITHUB_OUTPUT"
+          echo "release=$release_flag" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -46,6 +104,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
@@ -83,11 +143,9 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: build
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''
+    needs: [prepare, build]
+    if: needs.prepare.outputs.release == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Download all zips
         uses: actions/download-artifact@v4
@@ -100,8 +158,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.event.inputs.tag }}" dist/Haxor-*.zip \
+          gh release create "${{ needs.prepare.outputs.tag }}" dist/Haxor-*.zip \
             --repo "${{ github.repository }}" \
-            --target "${{ github.sha }}" \
-            --title "Haxor ${{ github.event.inputs.tag }}" \
+            --target "${{ needs.prepare.outputs.ref }}" \
+            --title "Haxor v${{ needs.prepare.outputs.version }}" \
             --notes "Self-contained Haxor plugin builds for win/linux/osx (x64 + arm64)."

--- a/.github/workflows/typewriter.yml
+++ b/.github/workflows/typewriter.yml
@@ -12,13 +12,71 @@ on:
       - '.github/workflows/typewriter.yml'
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Release tag to publish the zips under (e.g. se5-typewriter-v1.0). Leave empty to build artifacts only.'
+      release:
+        description: 'Publish a GitHub release. Bumps the minor in plugin.json and commits it back.'
+        type: boolean
+        default: false
+      version:
+        description: 'Optional explicit version (e.g. 1.2.0). Overrides the auto-minor-bump.'
         required: false
         type: string
 
+permissions:
+  contents: write
+
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set.outputs.version }}
+      tag:     ${{ steps.set.outputs.tag }}
+      ref:     ${{ steps.set.outputs.ref }}
+      release: ${{ steps.set.outputs.release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version (and bump on release)
+        id: set
+        run: |
+          set -e
+          current=$(jq -r .version se5/TypewriterEffect/plugin.json)
+          release_flag="false"
+          ref="${{ github.sha }}"
+          version="$current"
+          tag=""
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.release }}" = "true" ]; then
+            release_flag="true"
+            if [ -n "${{ inputs.version }}" ]; then
+              version="${{ inputs.version }}"
+            else
+              IFS=. read -r major minor patch <<< "$current"
+              version="$major.$((minor + 1)).0"
+            fi
+
+            tmp=$(mktemp)
+            jq --arg v "$version" '.version = $v' se5/TypewriterEffect/plugin.json > "$tmp"
+            mv "$tmp" se5/TypewriterEffect/plugin.json
+
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add se5/TypewriterEffect/plugin.json
+            git commit -m "Bump TypewriterEffect to $version [skip ci]"
+            git push
+            ref=$(git rev-parse HEAD)
+
+            IFS=. read -r major minor patch <<< "$version"
+            tag="se5-typewriter-v$major.$minor"
+          fi
+
+          echo "version=$version"  >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"          >> "$GITHUB_OUTPUT"
+          echo "ref=$ref"          >> "$GITHUB_OUTPUT"
+          echo "release=$release_flag" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -46,6 +104,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
@@ -83,11 +143,9 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: build
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''
+    needs: [prepare, build]
+    if: needs.prepare.outputs.release == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Download all zips
         uses: actions/download-artifact@v4
@@ -100,8 +158,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.event.inputs.tag }}" dist/TypewriterEffect-*.zip \
+          gh release create "${{ needs.prepare.outputs.tag }}" dist/TypewriterEffect-*.zip \
             --repo "${{ github.repository }}" \
-            --target "${{ github.sha }}" \
-            --title "TypewriterEffect ${{ github.event.inputs.tag }}" \
+            --target "${{ needs.prepare.outputs.ref }}" \
+            --title "TypewriterEffect v${{ needs.prepare.outputs.version }}" \
             --notes "Self-contained TypewriterEffect plugin builds for win/linux/osx (x64 + arm64)."

--- a/.github/workflows/word-censor.yml
+++ b/.github/workflows/word-censor.yml
@@ -14,13 +14,71 @@ on:
       - '.github/workflows/word-censor.yml'
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Release tag to publish the zips under (e.g. se5-word-censor-v1.0). Leave empty to build artifacts only.'
+      release:
+        description: 'Publish a GitHub release. Bumps the minor in plugin.json and commits it back.'
+        type: boolean
+        default: false
+      version:
+        description: 'Optional explicit version (e.g. 1.2.0). Overrides the auto-minor-bump.'
         required: false
         type: string
 
+permissions:
+  contents: write
+
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set.outputs.version }}
+      tag:     ${{ steps.set.outputs.tag }}
+      ref:     ${{ steps.set.outputs.ref }}
+      release: ${{ steps.set.outputs.release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version (and bump on release)
+        id: set
+        run: |
+          set -e
+          current=$(jq -r .version se5/WordCensor/plugin.json)
+          release_flag="false"
+          ref="${{ github.sha }}"
+          version="$current"
+          tag=""
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.release }}" = "true" ]; then
+            release_flag="true"
+            if [ -n "${{ inputs.version }}" ]; then
+              version="${{ inputs.version }}"
+            else
+              IFS=. read -r major minor patch <<< "$current"
+              version="$major.$((minor + 1)).0"
+            fi
+
+            tmp=$(mktemp)
+            jq --arg v "$version" '.version = $v' se5/WordCensor/plugin.json > "$tmp"
+            mv "$tmp" se5/WordCensor/plugin.json
+
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add se5/WordCensor/plugin.json
+            git commit -m "Bump WordCensor to $version [skip ci]"
+            git push
+            ref=$(git rev-parse HEAD)
+
+            IFS=. read -r major minor patch <<< "$version"
+            tag="se5-word-censor-v$major.$minor"
+          fi
+
+          echo "version=$version"  >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"          >> "$GITHUB_OUTPUT"
+          echo "ref=$ref"          >> "$GITHUB_OUTPUT"
+          echo "release=$release_flag" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -48,6 +106,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@v4
@@ -85,11 +145,9 @@ jobs:
 
   release:
     name: Publish GitHub Release
-    needs: build
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag != ''
+    needs: [prepare, build]
+    if: needs.prepare.outputs.release == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Download all zips
         uses: actions/download-artifact@v4
@@ -102,8 +160,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.event.inputs.tag }}" dist/WordCensor-*.zip \
+          gh release create "${{ needs.prepare.outputs.tag }}" dist/WordCensor-*.zip \
             --repo "${{ github.repository }}" \
-            --target "${{ github.sha }}" \
-            --title "WordCensor ${{ github.event.inputs.tag }}" \
+            --target "${{ needs.prepare.outputs.ref }}" \
+            --title "WordCensor v${{ needs.prepare.outputs.version }}" \
             --notes "Self-contained WordCensor plugin builds for win/linux/osx (x64 + arm64)."

--- a/se5/Haxor/PluginContract.cs
+++ b/se5/Haxor/PluginContract.cs
@@ -26,10 +26,26 @@ public sealed class PluginRequest
     public double FrameRate { get; set; }
     public string UiLanguage { get; set; } = string.Empty;
     public string Theme { get; set; } = string.Empty;
+
+    /// <summary>Active theme's colors so a plugin's UI can match Subtitle Edit. Null on older SE versions.</summary>
+    public PluginThemeColors? ThemeColors { get; set; }
+
     public string SeVersion { get; set; } = string.Empty;
 
     /// <summary>This plugin's settings as last persisted by Subtitle Edit (null on first run).</summary>
     public JsonElement? Settings { get; set; }
+}
+
+/// <summary>Active theme colors. All values are <c>#AARRGGBB</c> hex strings.</summary>
+public sealed class PluginThemeColors
+{
+    public bool IsDark { get; set; }
+    public string BackgroundColor { get; set; } = string.Empty;
+    public string ForegroundColor { get; set; } = string.Empty;
+    public string AccentColor { get; set; } = string.Empty;
+    public string BackgroundColorLighter { get; set; } = string.Empty;
+    public string BackgroundColorHeader { get; set; } = string.Empty;
+    public string BookmarkColor { get; set; } = string.Empty;
 }
 
 public sealed class PluginSubtitle

--- a/se5/Plugin-Shared/PluginApp.cs
+++ b/se5/Plugin-Shared/PluginApp.cs
@@ -21,9 +21,12 @@ public abstract class PluginApp : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        PluginDefaultStyles.Apply();
+
         if (PendingRequest is not null)
         {
             RequestedThemeVariant = ResolveThemeVariant(PendingRequest.Theme);
+            PluginThemeStyles.Apply(PendingRequest.ThemeColors);
 
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {

--- a/se5/Plugin-Shared/PluginContract.cs
+++ b/se5/Plugin-Shared/PluginContract.cs
@@ -18,8 +18,24 @@ public sealed class PluginRequest
     public double FrameRate { get; set; }
     public string UiLanguage { get; set; } = string.Empty;
     public string Theme { get; set; } = string.Empty;
+
+    /// <summary>Active theme's colors so the plugin's UI can match Subtitle Edit. Null on older SE versions.</summary>
+    public PluginThemeColors? ThemeColors { get; set; }
+
     public string SeVersion { get; set; } = string.Empty;
     public JsonElement? Settings { get; set; }
+}
+
+/// <summary>Active theme colors. All values are <c>#AARRGGBB</c> hex strings.</summary>
+public sealed class PluginThemeColors
+{
+    public bool IsDark { get; set; }
+    public string BackgroundColor { get; set; } = string.Empty;
+    public string ForegroundColor { get; set; } = string.Empty;
+    public string AccentColor { get; set; } = string.Empty;
+    public string BackgroundColorLighter { get; set; } = string.Empty;
+    public string BackgroundColorHeader { get; set; } = string.Empty;
+    public string BookmarkColor { get; set; } = string.Empty;
 }
 
 public sealed class PluginSubtitle

--- a/se5/Plugin-Shared/PluginDefaultStyles.cs
+++ b/se5/Plugin-Shared/PluginDefaultStyles.cs
@@ -1,0 +1,33 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Styling;
+
+namespace SubtitleEdit.Plugins.Shared;
+
+/// <summary>
+/// Theme-independent visual defaults applied to every SE5 plugin window
+/// (e.g. centered button text). Run by <see cref="PluginApp"/> at startup.
+/// </summary>
+public static class PluginDefaultStyles
+{
+    public static void Apply()
+    {
+        if (Application.Current is null)
+        {
+            return;
+        }
+
+        Application.Current.Styles.Add(new Styles
+        {
+            new Style(x => x.OfType<Button>())
+            {
+                Setters =
+                {
+                    new Setter(ContentControl.HorizontalContentAlignmentProperty, HorizontalAlignment.Center),
+                    new Setter(ContentControl.VerticalContentAlignmentProperty, VerticalAlignment.Center),
+                },
+            },
+        });
+    }
+}

--- a/se5/Plugin-Shared/PluginThemeStyles.cs
+++ b/se5/Plugin-Shared/PluginThemeStyles.cs
@@ -1,0 +1,188 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media;
+using Avalonia.Styling;
+using System;
+using System.Globalization;
+
+namespace SubtitleEdit.Plugins.Shared;
+
+/// <summary>
+/// Turns the <see cref="PluginThemeColors"/> sent by Subtitle Edit into Avalonia
+/// <see cref="Styles"/> so the plugin's window looks like an SE window.
+/// Mirrors <c>UiTheme.ApplyLighterDark</c> in Subtitle Edit.
+/// </summary>
+public static class PluginThemeStyles
+{
+    /// <summary>
+    /// Applies <paramref name="colors"/> to <see cref="Application.Current"/>.
+    /// No-op when <paramref name="colors"/> is null (older SE versions).
+    /// </summary>
+    public static void Apply(PluginThemeColors? colors)
+    {
+        if (colors is null || Application.Current is null)
+        {
+            return;
+        }
+
+        var bg = ParseHex(colors.BackgroundColor);
+        var fg = ParseHex(colors.ForegroundColor);
+        var bgLighter = ParseHex(colors.BackgroundColorLighter, bg);
+        var bgHeader = ParseHex(colors.BackgroundColorHeader, bg);
+
+        if (bg is null || fg is null)
+        {
+            return;
+        }
+
+        var bgBrush = new SolidColorBrush(bg.Value);
+        var fgBrush = new SolidColorBrush(fg.Value);
+        var bgLighterBrush = new SolidColorBrush(bgLighter ?? bg.Value);
+        var bgHeaderBrush = new SolidColorBrush(bgHeader ?? bg.Value);
+
+        if (colors.IsDark)
+        {
+            // Prevent Fluent's white-on-focus from overriding our foreground.
+            Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary
+            {
+                ["TextControlForeground"] = fgBrush,
+                ["TextControlForegroundPointerOver"] = fgBrush,
+                ["TextControlForegroundFocused"] = fgBrush,
+                ["TextControlForegroundDisabled"] = fgBrush,
+            });
+        }
+
+        Application.Current.Styles.Add(new Styles
+        {
+            new Style(x => x.OfType<Window>())
+            {
+                Setters =
+                {
+                    new Setter(Window.BackgroundProperty, bgBrush),
+                    new Setter(Window.ForegroundProperty, fgBrush),
+                },
+            },
+            new Style(x => x.OfType<TextBox>())
+            {
+                Setters =
+                {
+                    new Setter(TextBox.BackgroundProperty, bgBrush),
+                    new Setter(TextBox.ForegroundProperty, fgBrush),
+                },
+            },
+            new Style(x => x.OfType<TextBox>().Class(":focus").Template().OfType<Border>().Name("PART_BorderElement"))
+            {
+                Setters = { new Setter(Border.BackgroundProperty, bgBrush) },
+            },
+            new Style(x => x.OfType<TextBox>().Class(":pointerover").Template().OfType<Border>().Name("PART_BorderElement"))
+            {
+                Setters = { new Setter(Border.BackgroundProperty, bgLighterBrush) },
+            },
+            new Style(x => x.OfType<Button>())
+            {
+                Setters = { new Setter(Button.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<NumericUpDown>())
+            {
+                Setters =
+                {
+                    new Setter(NumericUpDown.BackgroundProperty, bgBrush),
+                    new Setter(NumericUpDown.ForegroundProperty, fgBrush),
+                },
+            },
+            new Style(x => x.OfType<ComboBox>())
+            {
+                Setters = { new Setter(ComboBox.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<RadioButton>())
+            {
+                Setters = { new Setter(RadioButton.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<CheckBox>())
+            {
+                Setters = { new Setter(CheckBox.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<ListBox>())
+            {
+                Setters = { new Setter(ListBox.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<Label>())
+            {
+                Setters = { new Setter(Label.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<TextBlock>())
+            {
+                Setters = { new Setter(TextBlock.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<MenuItem>())
+            {
+                Setters = { new Setter(MenuItem.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<ContextMenu>())
+            {
+                Setters =
+                {
+                    new Setter(TemplatedControl.BackgroundProperty, bgBrush),
+                    new Setter(TemplatedControl.ForegroundProperty, fgBrush),
+                },
+            },
+            new Style(x => x.OfType<FlyoutPresenter>())
+            {
+                Setters =
+                {
+                    new Setter(TemplatedControl.BackgroundProperty, bgBrush),
+                    new Setter(TemplatedControl.ForegroundProperty, fgBrush),
+                },
+            },
+            new Style(x => x.OfType<ButtonSpinner>())
+            {
+                Setters =
+                {
+                    new Setter(ButtonSpinner.BackgroundProperty, bgBrush),
+                    new Setter(ButtonSpinner.ForegroundProperty, fgBrush),
+                },
+            },
+        });
+    }
+
+    /// <summary>Parse <c>#RRGGBB</c> or <c>#AARRGGBB</c>. Returns null on empty/invalid input.</summary>
+    private static Color? ParseHex(string hex, Color? fallback = null)
+    {
+        if (string.IsNullOrWhiteSpace(hex))
+        {
+            return fallback;
+        }
+
+        var s = hex.StartsWith("#", StringComparison.Ordinal) ? hex.Substring(1) : hex;
+
+        try
+        {
+            if (s.Length == 6)
+            {
+                return Color.FromArgb(
+                    255,
+                    byte.Parse(s.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+            }
+
+            if (s.Length == 8)
+            {
+                return Color.FromArgb(
+                    byte.Parse(s.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+            }
+        }
+        catch (FormatException)
+        {
+        }
+        catch (OverflowException)
+        {
+        }
+
+        return fallback;
+    }
+}

--- a/se5/TypewriterEffect/App.axaml.cs
+++ b/se5/TypewriterEffect/App.axaml.cs
@@ -17,11 +17,15 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        PluginDefaultStyles.Apply();
+
         if (PendingRequest is not null)
         {
             RequestedThemeVariant = string.Equals(PendingRequest.Theme, "Dark", System.StringComparison.OrdinalIgnoreCase)
                 ? ThemeVariant.Dark
                 : ThemeVariant.Light;
+
+            PluginThemeStyles.Apply(PendingRequest.ThemeColors);
 
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {

--- a/se5/TypewriterEffect/PluginContract.cs
+++ b/se5/TypewriterEffect/PluginContract.cs
@@ -17,8 +17,24 @@ public sealed class PluginRequest
     public double FrameRate { get; set; }
     public string UiLanguage { get; set; } = string.Empty;
     public string Theme { get; set; } = string.Empty;
+
+    /// <summary>Active theme's colors so the plugin's UI can match Subtitle Edit. Null on older SE versions.</summary>
+    public PluginThemeColors? ThemeColors { get; set; }
+
     public string SeVersion { get; set; } = string.Empty;
     public JsonElement? Settings { get; set; }
+}
+
+/// <summary>Active theme colors. All values are <c>#AARRGGBB</c> hex strings.</summary>
+public sealed class PluginThemeColors
+{
+    public bool IsDark { get; set; }
+    public string BackgroundColor { get; set; } = string.Empty;
+    public string ForegroundColor { get; set; } = string.Empty;
+    public string AccentColor { get; set; } = string.Empty;
+    public string BackgroundColorLighter { get; set; } = string.Empty;
+    public string BackgroundColorHeader { get; set; } = string.Empty;
+    public string BookmarkColor { get; set; } = string.Empty;
 }
 
 public sealed class PluginSubtitle

--- a/se5/TypewriterEffect/PluginDefaultStyles.cs
+++ b/se5/TypewriterEffect/PluginDefaultStyles.cs
@@ -1,0 +1,33 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Styling;
+
+namespace SubtitleEdit.Plugins.TypewriterEffect;
+
+/// <summary>
+/// Theme-independent visual defaults applied to the plugin window
+/// (e.g. centered button text).
+/// </summary>
+public static class PluginDefaultStyles
+{
+    public static void Apply()
+    {
+        if (Application.Current is null)
+        {
+            return;
+        }
+
+        Application.Current.Styles.Add(new Styles
+        {
+            new Style(x => x.OfType<Button>())
+            {
+                Setters =
+                {
+                    new Setter(ContentControl.HorizontalContentAlignmentProperty, HorizontalAlignment.Center),
+                    new Setter(ContentControl.VerticalContentAlignmentProperty, VerticalAlignment.Center),
+                },
+            },
+        });
+    }
+}

--- a/se5/TypewriterEffect/PluginThemeStyles.cs
+++ b/se5/TypewriterEffect/PluginThemeStyles.cs
@@ -1,0 +1,165 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media;
+using Avalonia.Styling;
+using System;
+using System.Globalization;
+
+namespace SubtitleEdit.Plugins.TypewriterEffect;
+
+/// <summary>
+/// Turns the <see cref="PluginThemeColors"/> sent by Subtitle Edit into Avalonia
+/// <see cref="Styles"/> so the plugin's window looks like an SE window.
+/// Mirrors <c>UiTheme.ApplyLighterDark</c> in Subtitle Edit.
+/// </summary>
+public static class PluginThemeStyles
+{
+    public static void Apply(PluginThemeColors? colors)
+    {
+        if (colors is null || Application.Current is null)
+        {
+            return;
+        }
+
+        var bg = ParseHex(colors.BackgroundColor);
+        var fg = ParseHex(colors.ForegroundColor);
+        if (bg is null || fg is null)
+        {
+            return;
+        }
+
+        var bgLighter = ParseHex(colors.BackgroundColorLighter) ?? bg.Value;
+        var bgBrush = new SolidColorBrush(bg.Value);
+        var fgBrush = new SolidColorBrush(fg.Value);
+        var bgLighterBrush = new SolidColorBrush(bgLighter);
+
+        if (colors.IsDark)
+        {
+            Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary
+            {
+                ["TextControlForeground"] = fgBrush,
+                ["TextControlForegroundPointerOver"] = fgBrush,
+                ["TextControlForegroundFocused"] = fgBrush,
+                ["TextControlForegroundDisabled"] = fgBrush,
+            });
+        }
+
+        Application.Current.Styles.Add(new Styles
+        {
+            new Style(x => x.OfType<Window>())
+            {
+                Setters =
+                {
+                    new Setter(Window.BackgroundProperty, bgBrush),
+                    new Setter(Window.ForegroundProperty, fgBrush),
+                },
+            },
+            new Style(x => x.OfType<TextBox>())
+            {
+                Setters =
+                {
+                    new Setter(TextBox.BackgroundProperty, bgBrush),
+                    new Setter(TextBox.ForegroundProperty, fgBrush),
+                },
+            },
+            new Style(x => x.OfType<TextBox>().Class(":focus").Template().OfType<Border>().Name("PART_BorderElement"))
+            {
+                Setters = { new Setter(Border.BackgroundProperty, bgBrush) },
+            },
+            new Style(x => x.OfType<TextBox>().Class(":pointerover").Template().OfType<Border>().Name("PART_BorderElement"))
+            {
+                Setters = { new Setter(Border.BackgroundProperty, bgLighterBrush) },
+            },
+            new Style(x => x.OfType<Button>())
+            {
+                Setters = { new Setter(Button.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<NumericUpDown>())
+            {
+                Setters =
+                {
+                    new Setter(NumericUpDown.BackgroundProperty, bgBrush),
+                    new Setter(NumericUpDown.ForegroundProperty, fgBrush),
+                },
+            },
+            new Style(x => x.OfType<ComboBox>())
+            {
+                Setters = { new Setter(ComboBox.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<CheckBox>())
+            {
+                Setters = { new Setter(CheckBox.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<RadioButton>())
+            {
+                Setters = { new Setter(RadioButton.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<ListBox>())
+            {
+                Setters = { new Setter(ListBox.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<Label>())
+            {
+                Setters = { new Setter(Label.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<TextBlock>())
+            {
+                Setters = { new Setter(TextBlock.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<MenuItem>())
+            {
+                Setters = { new Setter(MenuItem.ForegroundProperty, fgBrush) },
+            },
+            new Style(x => x.OfType<ContextMenu>())
+            {
+                Setters =
+                {
+                    new Setter(TemplatedControl.BackgroundProperty, bgBrush),
+                    new Setter(TemplatedControl.ForegroundProperty, fgBrush),
+                },
+            },
+            new Style(x => x.OfType<ButtonSpinner>())
+            {
+                Setters =
+                {
+                    new Setter(ButtonSpinner.BackgroundProperty, bgBrush),
+                    new Setter(ButtonSpinner.ForegroundProperty, fgBrush),
+                },
+            },
+        });
+    }
+
+    private static Color? ParseHex(string hex)
+    {
+        if (string.IsNullOrWhiteSpace(hex))
+        {
+            return null;
+        }
+
+        var s = hex.StartsWith("#", StringComparison.Ordinal) ? hex.Substring(1) : hex;
+        try
+        {
+            if (s.Length == 6)
+            {
+                return Color.FromArgb(
+                    255,
+                    byte.Parse(s.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+            }
+            if (s.Length == 8)
+            {
+                return Color.FromArgb(
+                    byte.Parse(s.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture),
+                    byte.Parse(s.Substring(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture));
+            }
+        }
+        catch (FormatException) { }
+        catch (OverflowException) { }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- **Theme**: SE5 plugins now read `themeColors` from the request and apply SE's background/foreground/accent as Avalonia styles. Centralized in `Plugin-Shared/PluginThemeStyles` so `AmericanToBritish`, `BritishToAmerican`, and `WordCensor` inherit theming for free. `TypewriterEffect` mirrors it locally (it doesn't reference Plugin-Shared because the shared project embeds `WordList.xml` that TypewriterEffect doesn't need). `Haxor` only updates its contract — no UI to theme.
- **Buttons**: new `PluginDefaultStyles.Apply()` centers button content (horizontal + vertical) in every SE5 plugin window. Theme-independent, always runs.
- **Workflows**: `workflow_dispatch` now offers a `release` checkbox + optional `version` override (instead of typing a freeform tag). When release is checked, a new `prepare` job reads `plugin.json`, bumps the minor (or applies the override), writes the new version back, commits `[skip ci]`, pushes, and the build/release jobs use that new commit. Tag format unchanged (`se5-<slug>-vMAJOR.MINOR`); release title now includes full semver.

Push/PR builds are unaffected — `prepare` just reads the current version and produces no commit when not releasing.

## Companion PR
Requires https://github.com/SubtitleEdit/subtitleedit (the new `themeColors` field on the request) — older SE versions will simply omit it and the plugins fall back to Fluent defaults.

## Test plan
- [ ] CI builds all five SE5 plugin projects green.
- [ ] Manually: launch SE (with the companion PR) in Dark, run each themed plugin, confirm window background matches SE.
- [ ] Confirm button text is centered in each plugin window.
- [ ] Trigger one workflow via `workflow_dispatch` with `release` **unchecked** — verify artifacts produced, no commit, no release.
- [ ] Trigger one workflow with `release` **checked** and `version` empty — verify `plugin.json` bumped (e.g. 1.0.0 → 1.1.0), commit pushed, GH release created with the right tag/title.
- [ ] Branch protection note: if `main` is protected against direct pushes, the bump commit will fail. May need to allow GitHub Actions to bypass protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)