### PR TITLE
WordCensor: 3 censor modes (Grawlix / Replace / Alternative) and tidier UI

### DIFF
--- a/se5/WordCensor/MainWindow.axaml
+++ b/se5/WordCensor/MainWindow.axaml
@@ -6,14 +6,15 @@
         x:Class="SubtitleEdit.Plugins.WordCensor.MainWindow"
         mc:Ignorable="d"
         Title="Word censor"
-        Width="720" Height="600"
-        MinWidth="500" MinHeight="380"
+        Width="780" Height="640"
+        MinWidth="560" MinHeight="420"
         WindowStartupLocation="CenterScreen">
     <DockPanel Margin="20">
 
+        <!-- Bottom: status + apply/cancel -->
         <Grid DockPanel.Dock="Bottom"
               ColumnDefinitions="*,Auto,Auto"
-              Margin="0,14,0,0">
+              Margin="0,16,0,0">
             <TextBlock Grid.Column="0"
                        x:Name="SummaryLabel"
                        VerticalAlignment="Center"
@@ -32,25 +33,75 @@
                     IsDefault="True" />
         </Grid>
 
-        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Spacing="10" Margin="0,0,0,4">
-            <Button Content="Select all" Click="OnSelectAll" />
-            <Button Content="Select none" Click="OnSelectNone" />
-            <CheckBox x:Name="ColorRedCheck"
-                      Content="Highlight censored words in red"
-                      VerticalAlignment="Center"
-                      Margin="12,0,0,0" />
-        </StackPanel>
-
+        <!-- Title -->
         <TextBlock DockPanel.Dock="Top"
-                   FontSize="18"
+                   FontSize="20"
                    FontWeight="SemiBold"
                    Text="Word censor" />
 
         <TextBlock DockPanel.Dock="Top"
                    x:Name="SubtitleLabel"
-                   Margin="0,4,0,12"
+                   Margin="0,4,0,0"
                    Opacity="0.7"
                    TextWrapping="Wrap" />
+
+        <!-- Mode picker card -->
+        <Border DockPanel.Dock="Top"
+                Margin="0,14,0,0"
+                Padding="16,14"
+                CornerRadius="6"
+                Background="#11808080"
+                BorderBrush="#22808080"
+                BorderThickness="1">
+            <StackPanel Spacing="10">
+                <TextBlock Text="How should offensive words be replaced?"
+                           FontWeight="SemiBold" />
+
+                <StackPanel Orientation="Vertical" Spacing="6">
+                    <RadioButton x:Name="GrawlixModeRadio"
+                                 GroupName="CensorMode"
+                                 Content="Grawlix — mask with #@!?$%&amp; characters"
+                                 IsChecked="True" />
+
+                    <Grid ColumnDefinitions="Auto,8,*"
+                          VerticalAlignment="Center">
+                        <RadioButton Grid.Column="0"
+                                     x:Name="ReplacementModeRadio"
+                                     GroupName="CensorMode"
+                                     Content="Replace with text:" />
+                        <TextBox Grid.Column="2"
+                                 x:Name="ReplacementBox"
+                                 Text="[censored]"
+                                 MinWidth="180"
+                                 HorizontalAlignment="Left"
+                                 Watermark="[censored]" />
+                    </Grid>
+
+                    <RadioButton x:Name="AlternativeModeRadio"
+                                 GroupName="CensorMode"
+                                 Content="Swap with a random alternative word from the list" />
+                </StackPanel>
+
+                <CheckBox x:Name="ColorRedCheck"
+                          Content="Highlight censored words in red"
+                          Margin="0,4,0,0" />
+            </StackPanel>
+        </Border>
+
+        <!-- Selection controls -->
+        <Grid DockPanel.Dock="Top"
+              ColumnDefinitions="Auto,Auto,*"
+              Margin="0,12,0,4">
+            <Button Grid.Column="0"
+                    Content="Select all"
+                    Click="OnSelectAll"
+                    MinWidth="100" />
+            <Button Grid.Column="1"
+                    Content="Select none"
+                    Click="OnSelectNone"
+                    MinWidth="100"
+                    Margin="8,0,0,0" />
+        </Grid>
 
         <TextBlock DockPanel.Dock="Top"
                    x:Name="NoChangesLabel"
@@ -64,7 +115,8 @@
         <Border BorderBrush="#22808080"
                 BorderThickness="1"
                 CornerRadius="4"
-                Padding="0">
+                Padding="0"
+                Margin="0,4,0,0">
             <ListBox x:Name="ChangesList"
                      Background="Transparent"
                      SelectionMode="Single">

--- a/se5/WordCensor/MainWindow.axaml.cs
+++ b/se5/WordCensor/MainWindow.axaml.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 
@@ -14,6 +13,8 @@ namespace SubtitleEdit.Plugins.WordCensor;
 
 public partial class MainWindow : Window
 {
+    private const string DefaultReplacement = "[censored]";
+
     private readonly PluginRequest _request;
     private readonly List<SrtBlock> _blocks;
     private readonly WordCensorEngine _engine;
@@ -25,6 +26,10 @@ public partial class MainWindow : Window
     private ListBox _changesList = null!;
     private Button _applyButton = null!;
     private CheckBox _colorRedCheck = null!;
+    private RadioButton _grawlixRadio = null!;
+    private RadioButton _replacementRadio = null!;
+    private RadioButton _alternativeRadio = null!;
+    private TextBox _replacementBox = null!;
 
     public MainWindow() : this(new PluginRequest()) { }
 
@@ -36,8 +41,23 @@ public partial class MainWindow : Window
         _engine = new WordCensorEngine();
         _blocks = SubRipParser.Parse(request.Subtitle.SubRip);
 
-        _colorRedCheck.IsChecked = LoadColorRedSetting(request.Settings);
-        _colorRedCheck.IsCheckedChanged += (_, _) => RebuildProposals();
+        var (mode, replacement, colorRed) = LoadSettings(request.Settings);
+        SetMode(mode);
+        _replacementBox.Text = replacement;
+        _colorRedCheck.IsChecked = colorRed;
+
+        _grawlixRadio.IsCheckedChanged += (_, _) => OnModeOrOptionChanged();
+        _replacementRadio.IsCheckedChanged += (_, _) => OnModeOrOptionChanged();
+        _alternativeRadio.IsCheckedChanged += (_, _) => OnModeOrOptionChanged();
+        _colorRedCheck.IsCheckedChanged += (_, _) => OnModeOrOptionChanged();
+        _replacementBox.TextChanged += (_, _) =>
+        {
+            // Only re-build when the textbox actually affects the preview.
+            if (CurrentMode() == CensorMode.Replacement)
+            {
+                OnModeOrOptionChanged();
+            }
+        };
 
         BuildProposals();
         _changesList.ItemsSource = _proposals;
@@ -45,7 +65,7 @@ public partial class MainWindow : Window
         var scope = request.SelectedIndices.Count > 0
             ? $"the {request.SelectedIndices.Count} selected line(s)"
             : "all lines";
-        _subtitleLabel.Text = $"Replace offensive words with grawlix characters (#@!$%) in {scope}.";
+        _subtitleLabel.Text = $"Replace offensive words in {scope}. Pick a style below.";
 
         UpdateUiForProposals();
     }
@@ -59,6 +79,10 @@ public partial class MainWindow : Window
         _changesList = this.FindControl<ListBox>("ChangesList")!;
         _applyButton = this.FindControl<Button>("ApplyButton")!;
         _colorRedCheck = this.FindControl<CheckBox>("ColorRedCheck")!;
+        _grawlixRadio = this.FindControl<RadioButton>("GrawlixModeRadio")!;
+        _replacementRadio = this.FindControl<RadioButton>("ReplacementModeRadio")!;
+        _alternativeRadio = this.FindControl<RadioButton>("AlternativeModeRadio")!;
+        _replacementBox = this.FindControl<TextBox>("ReplacementBox")!;
     }
 
     protected override void OnOpened(EventArgs e)
@@ -67,9 +91,30 @@ public partial class MainWindow : Window
         this.BringToForeground();
     }
 
+    private CensorOptions BuildOptions() => new()
+    {
+        Mode = CurrentMode(),
+        Replacement = string.IsNullOrEmpty(_replacementBox.Text) ? DefaultReplacement : _replacementBox.Text,
+        ColorRed = _colorRedCheck.IsChecked == true,
+    };
+
+    private CensorMode CurrentMode()
+    {
+        if (_replacementRadio.IsChecked == true) return CensorMode.Replacement;
+        if (_alternativeRadio.IsChecked == true) return CensorMode.Alternative;
+        return CensorMode.Grawlix;
+    }
+
+    private void SetMode(CensorMode mode)
+    {
+        _grawlixRadio.IsChecked = mode == CensorMode.Grawlix;
+        _replacementRadio.IsChecked = mode == CensorMode.Replacement;
+        _alternativeRadio.IsChecked = mode == CensorMode.Alternative;
+    }
+
     private void BuildProposals()
     {
-        var colorRed = _colorRedCheck.IsChecked == true;
+        var options = BuildOptions();
         var selected = new HashSet<int>(_request.SelectedIndices);
         var applyToAll = selected.Count == 0;
 
@@ -86,7 +131,7 @@ public partial class MainWindow : Window
                 continue;
             }
 
-            if (_engine.TryCensor(_blocks[i].Text, colorRed, out var censored))
+            if (_engine.TryCensor(_blocks[i].Text, options, out var censored))
             {
                 var proposal = new ChangeProposal(i, _blocks[i].Text, censored);
                 proposal.PropertyChanged += OnProposalChanged;
@@ -95,10 +140,10 @@ public partial class MainWindow : Window
         }
     }
 
-    private void RebuildProposals()
+    private void OnModeOrOptionChanged()
     {
-        // Re-censor existing proposals so the colour-toggle is reflected in the preview.
-        // The grawlix characters re-randomise, which is fine - the user is comparing approaches.
+        // Re-censor existing proposals so the new mode/colour/text is reflected in the preview.
+        // Grawlix re-randomises and Alternative re-rolls, which is fine — the user is comparing approaches.
         var previousInclude = _proposals.ToDictionary(p => p.LineIndex, p => p.Include);
         BuildProposals();
         foreach (var p in _proposals)
@@ -199,7 +244,7 @@ public partial class MainWindow : Window
                     Format = "SubRip",
                     Native = SubRipParser.Serialize(_blocks),
                 },
-                Settings = BuildSettings(_colorRedCheck.IsChecked == true),
+                Settings = BuildSettings(BuildOptions()),
             };
         }
         catch (Exception ex)
@@ -210,22 +255,50 @@ public partial class MainWindow : Window
         Close();
     }
 
-    private static bool LoadColorRedSetting(JsonElement? settings)
+    private static (CensorMode mode, string replacement, bool colorRed) LoadSettings(JsonElement? settings)
     {
+        var mode = CensorMode.Grawlix;
+        var replacement = DefaultReplacement;
+        var colorRed = false;
+
         if (settings is null || settings.Value.ValueKind != JsonValueKind.Object)
         {
-            return false;
+            return (mode, replacement, colorRed);
         }
-        if (settings.Value.TryGetProperty("colorRed", out var value) && value.ValueKind == JsonValueKind.True)
+
+        var root = settings.Value;
+
+        if (root.TryGetProperty("mode", out var modeProp) && modeProp.ValueKind == JsonValueKind.String &&
+            Enum.TryParse<CensorMode>(modeProp.GetString(), ignoreCase: true, out var parsed))
         {
-            return true;
+            mode = parsed;
         }
-        return false;
+        if (root.TryGetProperty("replacement", out var rep) && rep.ValueKind == JsonValueKind.String)
+        {
+            var s = rep.GetString();
+            if (!string.IsNullOrEmpty(s))
+            {
+                replacement = s;
+            }
+        }
+        if (root.TryGetProperty("colorRed", out var cr) && cr.ValueKind == JsonValueKind.True)
+        {
+            colorRed = true;
+        }
+
+        return (mode, replacement, colorRed);
     }
 
-    private static JsonElement BuildSettings(bool colorRed)
+    private static JsonElement BuildSettings(CensorOptions options)
     {
-        using var doc = JsonDocument.Parse($"{{\"colorRed\":{colorRed.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()}}}");
+        var dto = new
+        {
+            mode = options.Mode.ToString(),
+            replacement = options.Replacement,
+            colorRed = options.ColorRed,
+        };
+        var json = JsonSerializer.Serialize(dto);
+        using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
     }
 }

--- a/se5/WordCensor/WordCensorEngine.cs
+++ b/se5/WordCensor/WordCensorEngine.cs
@@ -1,15 +1,41 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace SubtitleEdit.Plugins.WordCensor;
 
+/// <summary>How a matched offensive word should be replaced.</summary>
+public enum CensorMode
+{
+    /// <summary>Replace the first ~50% of letters with random grawlix characters (@#!?$%&amp;).</summary>
+    Grawlix = 0,
+
+    /// <summary>Replace the whole match with a user-supplied string, e.g. "[censored]".</summary>
+    Replacement = 1,
+
+    /// <summary>Replace the whole match with another (different) random word from the list.</summary>
+    Alternative = 2,
+}
+
+/// <summary>Per-call options for <see cref="WordCensorEngine.Censor"/>.</summary>
+public sealed class CensorOptions
+{
+    public CensorMode Mode { get; set; } = CensorMode.Grawlix;
+
+    /// <summary>Used when <see cref="Mode"/> is <see cref="CensorMode.Replacement"/>.</summary>
+    public string Replacement { get; set; } = "[censored]";
+
+    /// <summary>When true, wrap each replacement in <c>&lt;font color="#ff0000"&gt;...&lt;/font&gt;</c>.</summary>
+    public bool ColorRed { get; set; }
+}
+
 /// <summary>
-/// Censors offensive words by replacing the first ~50% of each match with
-/// random "grawlix" characters (@#!?$%&amp;). Optionally wraps the censored
-/// word in a red &lt;font&gt; tag. Matches whole words case-insensitively;
-/// multi-word phrases in the list are also matched verbatim.
+/// Censors offensive words. Three modes are supported via <see cref="CensorMode"/>:
+/// grawlix masking, fixed-string replacement, or substitution with another random
+/// word from the same list. Matches whole words case-insensitively; multi-word
+/// phrases in the list are matched verbatim.
 /// </summary>
 public sealed class WordCensorEngine
 {
@@ -18,6 +44,7 @@ public sealed class WordCensorEngine
 
     private readonly HashSet<string> _singleWords;
     private readonly List<string> _multiWordPhrases;
+    private readonly List<string> _allWords;
     private readonly Random _random;
 
     public WordCensorEngine(int? randomSeed = null)
@@ -26,15 +53,13 @@ public sealed class WordCensorEngine
         _multiWordPhrases = new List<string>();
         _random = randomSeed.HasValue ? new Random(randomSeed.Value) : new Random();
         LoadBuiltInList();
+        _allWords = _singleWords.Concat(_multiWordPhrases).ToList();
     }
 
-    public int WordCount => _singleWords.Count + _multiWordPhrases.Count;
+    public int WordCount => _allWords.Count;
 
-    /// <summary>
-    /// Censors all offensive words in <paramref name="text"/>. When <paramref name="colorRed"/> is true,
-    /// each censored word is wrapped in &lt;font color="#ff0000"&gt;...&lt;/font&gt;.
-    /// </summary>
-    public string Censor(string text, bool colorRed)
+    /// <summary>Censors all offensive words in <paramref name="text"/> using <paramref name="options"/>.</summary>
+    public string Censor(string text, CensorOptions options)
     {
         if (string.IsNullOrEmpty(text))
         {
@@ -44,7 +69,7 @@ public sealed class WordCensorEngine
         // First handle multi-word phrases (they need to match before single-word logic eats their pieces).
         foreach (var phrase in _multiWordPhrases)
         {
-            text = ReplacePhrase(text, phrase, colorRed);
+            text = ReplacePhrase(text, phrase, options);
         }
 
         // Then walk single words.
@@ -62,7 +87,7 @@ public sealed class WordCensorEngine
                 var word = text.Substring(start, i - start);
                 if (_singleWords.Contains(word))
                 {
-                    sb.Append(MaybeColor(Grawlix(word), colorRed));
+                    sb.Append(MaybeColor(BuildReplacement(word, options), options.ColorRed));
                 }
                 else
                 {
@@ -79,13 +104,13 @@ public sealed class WordCensorEngine
         return sb.ToString();
     }
 
-    public bool TryCensor(string text, bool colorRed, out string censored)
+    public bool TryCensor(string text, CensorOptions options, out string censored)
     {
-        censored = Censor(text, colorRed);
+        censored = Censor(text, options);
         return !string.Equals(text, censored, StringComparison.Ordinal);
     }
 
-    private string ReplacePhrase(string text, string phrase, bool colorRed)
+    private string ReplacePhrase(string text, string phrase, CensorOptions options)
     {
         var idx = 0;
         var sb = new StringBuilder(text.Length);
@@ -103,7 +128,8 @@ public sealed class WordCensorEngine
             sb.Append(text, idx, hit - idx);
             if (startsClean && endsClean)
             {
-                sb.Append(MaybeColor(Grawlix(text.Substring(hit, phrase.Length)), colorRed));
+                var match = text.Substring(hit, phrase.Length);
+                sb.Append(MaybeColor(BuildReplacement(match, options), options.ColorRed));
             }
             else
             {
@@ -112,6 +138,58 @@ public sealed class WordCensorEngine
             idx = hit + phrase.Length;
         }
         return sb.ToString();
+    }
+
+    private string BuildReplacement(string match, CensorOptions options) => options.Mode switch
+    {
+        CensorMode.Replacement => string.IsNullOrEmpty(options.Replacement) ? "[censored]" : options.Replacement,
+        CensorMode.Alternative => PickAlternative(match),
+        _ => Grawlix(match),
+    };
+
+    private string PickAlternative(string original)
+    {
+        if (_allWords.Count <= 1)
+        {
+            return original;
+        }
+
+        // Try a few times to avoid the original word; give up if everything resolves to it.
+        for (var attempt = 0; attempt < 8; attempt++)
+        {
+            var pick = _allWords[_random.Next(_allWords.Count)];
+            if (!string.Equals(pick, original, StringComparison.OrdinalIgnoreCase))
+            {
+                return MatchCase(pick, original);
+            }
+        }
+        return original;
+    }
+
+    /// <summary>Apply the rough case pattern of <paramref name="template"/> to <paramref name="word"/>.</summary>
+    private static string MatchCase(string word, string template)
+    {
+        if (string.IsNullOrEmpty(template))
+        {
+            return word;
+        }
+
+        var allUpper = template.All(c => !char.IsLetter(c) || char.IsUpper(c));
+        if (allUpper && template.Any(char.IsLetter))
+        {
+            return word.ToUpperInvariant();
+        }
+
+        if (char.IsUpper(template[0]))
+        {
+            if (word.Length == 0)
+            {
+                return word;
+            }
+            return char.ToUpperInvariant(word[0]) + word.Substring(1).ToLowerInvariant();
+        }
+
+        return word.ToLowerInvariant();
     }
 
     private string Grawlix(string word)


### PR DESCRIPTION
## Summary
- Engine refactored to take a `CensorOptions { Mode, Replacement, ColorRed }` object.
- **Three modes:**
  - **Grawlix** — existing behaviour: mask first ~50% with `#@!?$%&`.
  - **Replace with text** — replace the whole match with a user-editable string (default `[censored]`).
  - **Random alternative word** — swap with another word from the bad-word list itself. Rough case pattern is preserved (`FUCK → DAMN`, `Fuck → Damn`).
- UI gets a 'How should offensive words be replaced?' card with the 3 modes as radio buttons, the replacement text box inline with its radio, and the highlight-in-red checkbox tucked into the same card. Window grew to 780x640.
- Settings now persists `mode + replacement + colorRed` (was just `colorRed`); older settings still load with sensible defaults for missing fields.

## Test plan
- [ ] Run on a subtitle containing offensive words; verify all 3 modes produce visibly different output in the preview.
- [ ] Toggle modes — preview updates immediately, line selection (include/exclude) is preserved across re-builds.
- [ ] Edit the replacement string with **Replace** mode active — preview re-renders on each keystroke.
- [ ] Toggle 'Highlight in red' — replacements wrap in `<font color="#ff0000">…</font>`.
- [ ] Close & reopen the plugin — last-used mode + replacement string + colour flag are restored.
- [ ] Verify Alternative mode doesn't loop forever even on a bad-word list of size 1 (degenerate case returns the original).

🤖 Generated with [Claude Code](https://claude.com/claude-code)