### PR TITLE
Retry release-bump push with --rebase on concurrent contention

### DIFF
--- a/.github/workflows/american-to-british.yml
+++ b/.github/workflows/american-to-british.yml
@@ -65,7 +65,20 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add se5/AmericanToBritish/plugin.json
             git commit -m "Bump AmericanToBritish to $version [skip ci]"
-            git push
+
+            # Retry-with-rebase: if a concurrent release dispatched for a different
+            # plugin won the push first, pull --rebase and try again.
+            attempts=0
+            while ! git push 2>/tmp/push.err; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge 5 ]; then
+                echo "Failed to push after $attempts attempts:" >&2
+                cat /tmp/push.err >&2
+                exit 1
+              fi
+              echo "Push rejected (attempt $attempts), pulling --rebase and retrying..."
+              git pull --rebase --no-edit
+            done
             ref=$(git rev-parse HEAD)
 
             IFS=. read -r major minor patch <<< "$version"

--- a/.github/workflows/british-to-american.yml
+++ b/.github/workflows/british-to-american.yml
@@ -65,7 +65,20 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add se5/BritishToAmerican/plugin.json
             git commit -m "Bump BritishToAmerican to $version [skip ci]"
-            git push
+
+            # Retry-with-rebase: if a concurrent release dispatched for a different
+            # plugin won the push first, pull --rebase and try again.
+            attempts=0
+            while ! git push 2>/tmp/push.err; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge 5 ]; then
+                echo "Failed to push after $attempts attempts:" >&2
+                cat /tmp/push.err >&2
+                exit 1
+              fi
+              echo "Push rejected (attempt $attempts), pulling --rebase and retrying..."
+              git pull --rebase --no-edit
+            done
             ref=$(git rev-parse HEAD)
 
             IFS=. read -r major minor patch <<< "$version"

--- a/.github/workflows/haxor.yml
+++ b/.github/workflows/haxor.yml
@@ -63,7 +63,20 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add se5/Haxor/plugin.json
             git commit -m "Bump Haxor to $version [skip ci]"
-            git push
+
+            # Retry-with-rebase: if a concurrent release dispatched for a different
+            # plugin won the push first, pull --rebase and try again.
+            attempts=0
+            while ! git push 2>/tmp/push.err; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge 5 ]; then
+                echo "Failed to push after $attempts attempts:" >&2
+                cat /tmp/push.err >&2
+                exit 1
+              fi
+              echo "Push rejected (attempt $attempts), pulling --rebase and retrying..."
+              git pull --rebase --no-edit
+            done
             ref=$(git rev-parse HEAD)
 
             IFS=. read -r major minor patch <<< "$version"

--- a/.github/workflows/typewriter.yml
+++ b/.github/workflows/typewriter.yml
@@ -63,7 +63,20 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add se5/TypewriterEffect/plugin.json
             git commit -m "Bump TypewriterEffect to $version [skip ci]"
-            git push
+
+            # Retry-with-rebase: if a concurrent release dispatched for a different
+            # plugin won the push first, pull --rebase and try again.
+            attempts=0
+            while ! git push 2>/tmp/push.err; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge 5 ]; then
+                echo "Failed to push after $attempts attempts:" >&2
+                cat /tmp/push.err >&2
+                exit 1
+              fi
+              echo "Push rejected (attempt $attempts), pulling --rebase and retrying..."
+              git pull --rebase --no-edit
+            done
             ref=$(git rev-parse HEAD)
 
             IFS=. read -r major minor patch <<< "$version"

--- a/.github/workflows/word-censor.yml
+++ b/.github/workflows/word-censor.yml
@@ -65,7 +65,20 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add se5/WordCensor/plugin.json
             git commit -m "Bump WordCensor to $version [skip ci]"
-            git push
+
+            # Retry-with-rebase: if a concurrent release dispatched for a different
+            # plugin won the push first, pull --rebase and try again.
+            attempts=0
+            while ! git push 2>/tmp/push.err; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge 5 ]; then
+                echo "Failed to push after $attempts attempts:" >&2
+                cat /tmp/push.err >&2
+                exit 1
+              fi
+              echo "Push rejected (attempt $attempts), pulling --rebase and retrying..."
+              git pull --rebase --no-edit
+            done
             ref=$(git rev-parse HEAD)
 
             IFS=. read -r major minor patch <<< "$version"


### PR DESCRIPTION
## Summary
Follow-up to merged #275. When several SE5 plugin workflows are dispatched at the same time (as just happened during the 1.1.0 release run), they all check out the same SHA, all create their bump commits, and only one wins the push. The other 4 failed with `! [rejected] main -> main (fetch first)` and had to be retriggered serially.

This PR wraps the bump push in a small retry-with-rebase loop in all 5 prepare jobs:

```bash
attempts=0
while ! git push 2>/tmp/push.err; do
  attempts=$((attempts + 1))
  if [ "$attempts" -ge 5 ]; then
    echo "Failed to push after $attempts attempts:" >&2
    cat /tmp/push.err >&2
    exit 1
  fi
  echo "Push rejected (attempt $attempts), pulling --rebase and retrying..."
  git pull --rebase --no-edit
done
```

Different plugins touch different `plugin.json` files, so the rebase never conflicts. Same-plugin double-dispatch is not a realistic case (you wouldn't release the same plugin twice in parallel).

## Test plan
- [ ] After merge, dispatch all 5 release workflows in quick succession again — all 5 prepare jobs should now succeed, with the later ones logging *"Push rejected (attempt N), pulling --rebase and retrying..."*.
- [ ] Single-workflow release path is unchanged (one push attempt, no retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)