### PR TITLE
Add RemoveUnicodeCharacters SE5 plugin

### DIFF
--- a/.github/workflows/remove-unicode-characters.yml
+++ b/.github/workflows/remove-unicode-characters.yml
@@ -1,0 +1,180 @@
+name: Build RemoveUnicodeCharacters (SE5)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'se5/RemoveUnicodeCharacters/**'
+      - 'se5/Plugin-Shared/**'
+      - '.github/workflows/remove-unicode-characters.yml'
+  pull_request:
+    paths:
+      - 'se5/RemoveUnicodeCharacters/**'
+      - 'se5/Plugin-Shared/**'
+      - '.github/workflows/remove-unicode-characters.yml'
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Publish a GitHub release. Bumps the minor in plugin.json and commits it back.'
+        type: boolean
+        default: false
+      version:
+        description: 'Optional explicit version (e.g. 1.2.0). Overrides the auto-minor-bump.'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set.outputs.version }}
+      tag:     ${{ steps.set.outputs.tag }}
+      ref:     ${{ steps.set.outputs.ref }}
+      release: ${{ steps.set.outputs.release }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version (and bump on release)
+        id: set
+        run: |
+          set -e
+          current=$(jq -r .version se5/RemoveUnicodeCharacters/plugin.json)
+          release_flag="false"
+          ref="${{ github.sha }}"
+          version="$current"
+          tag=""
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.release }}" = "true" ]; then
+            release_flag="true"
+            if [ -n "${{ inputs.version }}" ]; then
+              version="${{ inputs.version }}"
+            else
+              IFS=. read -r major minor patch <<< "$current"
+              version="$major.$((minor + 1)).0"
+            fi
+
+            tmp=$(mktemp)
+            jq --arg v "$version" '.version = $v' se5/RemoveUnicodeCharacters/plugin.json > "$tmp"
+            mv "$tmp" se5/RemoveUnicodeCharacters/plugin.json
+
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add se5/RemoveUnicodeCharacters/plugin.json
+            git commit -m "Bump RemoveUnicodeCharacters to $version [skip ci]"
+
+            # Retry-with-rebase: if a concurrent release dispatched for a different
+            # plugin won the push first, pull --rebase and try again.
+            attempts=0
+            while ! git push 2>/tmp/push.err; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge 5 ]; then
+                echo "Failed to push after $attempts attempts:" >&2
+                cat /tmp/push.err >&2
+                exit 1
+              fi
+              echo "Push rejected (attempt $attempts), pulling --rebase and retrying..."
+              git pull --rebase --no-edit
+            done
+            ref=$(git rev-parse HEAD)
+
+            IFS=. read -r major minor patch <<< "$version"
+            tag="se5-remove-unicode-characters-v$major.$minor"
+          fi
+
+          echo "version=$version"  >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"          >> "$GITHUB_OUTPUT"
+          echo "ref=$ref"          >> "$GITHUB_OUTPUT"
+          echo "release=$release_flag" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: win-x64
+            os: windows
+            exe: RemoveUnicodeCharacters.exe
+          - rid: win-arm64
+            os: windows
+            exe: RemoveUnicodeCharacters.exe
+          - rid: linux-x64
+            os: linux
+            exe: RemoveUnicodeCharacters
+          - rid: linux-arm64
+            os: linux
+            exe: RemoveUnicodeCharacters
+          - rid: osx-x64
+            os: macos
+            exe: RemoveUnicodeCharacters
+          - rid: osx-arm64
+            os: macos
+            exe: RemoveUnicodeCharacters
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Publish self-contained (${{ matrix.rid }})
+        working-directory: se5/RemoveUnicodeCharacters
+        run: |
+          dotnet publish RemoveUnicodeCharacters.csproj \
+            -c Release \
+            -r ${{ matrix.rid }} \
+            --self-contained true \
+            -p:DebugType=None \
+            -p:DebugSymbols=false \
+            -o staging/RemoveUnicodeCharacters
+
+      - name: Rewrite plugin.json for ${{ matrix.os }}
+        working-directory: se5/RemoveUnicodeCharacters
+        run: |
+          jq '
+            del(.runtime, .entry) |
+            .executables = { "${{ matrix.os }}": "${{ matrix.exe }}" }
+          ' plugin.json > staging/RemoveUnicodeCharacters/plugin.json
+
+      - name: Package zip
+        working-directory: se5/RemoveUnicodeCharacters/staging
+        run: zip -r "$GITHUB_WORKSPACE/RemoveUnicodeCharacters-${{ matrix.rid }}.zip" RemoveUnicodeCharacters
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: RemoveUnicodeCharacters-${{ matrix.rid }}
+          path: RemoveUnicodeCharacters-${{ matrix.rid }}.zip
+
+  release:
+    name: Publish GitHub Release
+    needs: [prepare, build]
+    if: needs.prepare.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all zips
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: RemoveUnicodeCharacters-*
+          merge-multiple: true
+
+      - name: Create release and upload zips
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ needs.prepare.outputs.tag }}" dist/RemoveUnicodeCharacters-*.zip \
+            --repo "${{ github.repository }}" \
+            --target "${{ needs.prepare.outputs.ref }}" \
+            --title "RemoveUnicodeCharacters v${{ needs.prepare.outputs.version }}" \
+            --notes "Self-contained RemoveUnicodeCharacters plugin builds for win/linux/osx (x64 + arm64)."

--- a/se5-plugins.json
+++ b/se5-plugins.json
@@ -84,6 +84,23 @@
         "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-haxor-v1.1/Haxor-osx-x64.zip",
         "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-haxor-v1.1/Haxor-osx-arm64.zip"
       }
+    },
+    {
+      "name": "Remove Unicode characters",
+      "description": "Detects non-ANSI characters in the subtitle and lets you remove or replace each one. Shows a checkable preview with the count and line numbers per character.",
+      "version": "1.1.0",
+      "author": "Subtitle Edit",
+      "url": "https://github.com/SubtitleEdit/plugins/tree/main/se5/RemoveUnicodeCharacters",
+      "date": "2026-05-26",
+      "minSeVersion": "5.0.0",
+      "downloads": {
+        "win-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-remove-unicode-characters-v1.1/RemoveUnicodeCharacters-win-x64.zip",
+        "win-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-remove-unicode-characters-v1.1/RemoveUnicodeCharacters-win-arm64.zip",
+        "linux-x64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-remove-unicode-characters-v1.1/RemoveUnicodeCharacters-linux-x64.zip",
+        "linux-arm64": "https://github.com/SubtitleEdit/plugins/releases/download/se5-remove-unicode-characters-v1.1/RemoveUnicodeCharacters-linux-arm64.zip",
+        "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-remove-unicode-characters-v1.1/RemoveUnicodeCharacters-osx-x64.zip",
+        "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-remove-unicode-characters-v1.1/RemoveUnicodeCharacters-osx-arm64.zip"
+      }
     }
   ]
 }

--- a/se5/RemoveUnicodeCharacters/App.axaml
+++ b/se5/RemoveUnicodeCharacters/App.axaml
@@ -1,0 +1,8 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="SubtitleEdit.Plugins.RemoveUnicodeCharacters.App"
+             RequestedThemeVariant="Default">
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/se5/RemoveUnicodeCharacters/App.axaml.cs
+++ b/se5/RemoveUnicodeCharacters/App.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using SubtitleEdit.Plugins.Shared;
+
+namespace SubtitleEdit.Plugins.RemoveUnicodeCharacters;
+
+public partial class App : PluginApp
+{
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    protected override Window CreateMainWindow(PluginRequest request) => new MainWindow(request);
+}

--- a/se5/RemoveUnicodeCharacters/MainWindow.axaml
+++ b/se5/RemoveUnicodeCharacters/MainWindow.axaml
@@ -1,0 +1,126 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="using:SubtitleEdit.Plugins.RemoveUnicodeCharacters"
+        x:Class="SubtitleEdit.Plugins.RemoveUnicodeCharacters.MainWindow"
+        mc:Ignorable="d"
+        Title="Remove Unicode characters"
+        Width="860" Height="620"
+        MinWidth="640" MinHeight="400"
+        WindowStartupLocation="CenterScreen">
+    <DockPanel Margin="20">
+
+        <Grid DockPanel.Dock="Bottom"
+              ColumnDefinitions="*,Auto,Auto"
+              Margin="0,14,0,0">
+            <TextBlock Grid.Column="0"
+                       x:Name="SummaryLabel"
+                       VerticalAlignment="Center"
+                       Opacity="0.75" />
+            <Button Grid.Column="1"
+                    Content="Cancel"
+                    Click="OnCancel"
+                    MinWidth="100"
+                    Margin="0,0,8,0" />
+            <Button Grid.Column="2"
+                    x:Name="ApplyButton"
+                    Content="Apply"
+                    Click="OnApply"
+                    MinWidth="100"
+                    Classes="accent"
+                    IsDefault="True" />
+        </Grid>
+
+        <StackPanel Orientation="Horizontal"
+                    DockPanel.Dock="Top"
+                    Spacing="10"
+                    Margin="0,0,0,4">
+            <Button Content="Select all" Click="OnSelectAll" />
+            <Button Content="Select none" Click="OnSelectNone" />
+            <Button Content="Google selected"
+                    Click="OnGoogleSelected"
+                    x:Name="GoogleButton"
+                    IsEnabled="False" />
+        </StackPanel>
+
+        <TextBlock DockPanel.Dock="Top"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   Text="Remove Unicode characters" />
+
+        <TextBlock DockPanel.Dock="Top"
+                   x:Name="SubtitleLabel"
+                   Margin="0,4,0,12"
+                   Opacity="0.7"
+                   TextWrapping="Wrap" />
+
+        <TextBlock DockPanel.Dock="Top"
+                   x:Name="NoCharsLabel"
+                   FontSize="14"
+                   Margin="0,30,0,0"
+                   HorizontalAlignment="Center"
+                   Opacity="0.65"
+                   Text="No Unicode characters found in the selected lines."
+                   IsVisible="False" />
+
+        <Border DockPanel.Dock="Top"
+                x:Name="HeaderBorder"
+                BorderBrush="#22808080"
+                BorderThickness="1,1,1,0"
+                CornerRadius="4,4,0,0"
+                Padding="4,6"
+                IsVisible="False">
+            <Grid ColumnDefinitions="32,92,46,60,200,*">
+                <TextBlock Grid.Column="1" Text="Code"     FontWeight="SemiBold" Opacity="0.7" />
+                <TextBlock Grid.Column="2" Text="Char"     FontWeight="SemiBold" Opacity="0.7" />
+                <TextBlock Grid.Column="3" Text="Count"    FontWeight="SemiBold" Opacity="0.7" />
+                <TextBlock Grid.Column="4" Text="Replace with" FontWeight="SemiBold" Opacity="0.7" Margin="6,0,0,0" />
+                <TextBlock Grid.Column="5" Text="Lines"    FontWeight="SemiBold" Opacity="0.7" Margin="6,0,0,0" />
+            </Grid>
+        </Border>
+
+        <Border x:Name="ListBorder"
+                BorderBrush="#22808080"
+                BorderThickness="1"
+                CornerRadius="0,0,4,4"
+                Padding="0">
+            <ListBox x:Name="CharsList"
+                     Background="Transparent"
+                     SelectionMode="Single">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="local:UnicodeCharRow">
+                        <Grid ColumnDefinitions="32,92,46,60,200,*" Margin="0,6">
+                            <CheckBox Grid.Column="0"
+                                      IsChecked="{Binding Include, Mode=TwoWay}"
+                                      VerticalAlignment="Center" />
+                            <TextBlock Grid.Column="1"
+                                       Text="{Binding HexCode}"
+                                       VerticalAlignment="Center"
+                                       FontFamily="Consolas,Menlo,Courier New" />
+                            <TextBlock Grid.Column="2"
+                                       Text="{Binding Glyph}"
+                                       FontSize="16"
+                                       VerticalAlignment="Center" />
+                            <TextBlock Grid.Column="3"
+                                       Text="{Binding Count}"
+                                       VerticalAlignment="Center"
+                                       Opacity="0.8" />
+                            <TextBox Grid.Column="4"
+                                     Text="{Binding Replacement, Mode=TwoWay}"
+                                     Margin="6,0,8,0"
+                                     VerticalAlignment="Center"
+                                     Watermark="(remove)" />
+                            <TextBlock Grid.Column="5"
+                                       Text="{Binding LinesText}"
+                                       VerticalAlignment="Center"
+                                       TextWrapping="Wrap"
+                                       Opacity="0.7"
+                                       FontSize="12" />
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Border>
+    </DockPanel>
+</Window>

--- a/se5/RemoveUnicodeCharacters/MainWindow.axaml.cs
+++ b/se5/RemoveUnicodeCharacters/MainWindow.axaml.cs
@@ -1,0 +1,345 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using SubtitleEdit.Plugins.Shared;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+
+namespace SubtitleEdit.Plugins.RemoveUnicodeCharacters;
+
+public partial class MainWindow : Window
+{
+    /// <summary>Built-in default replacements (used when the user has no persisted setting for a character).</summary>
+    private static readonly Dictionary<char, string> DefaultReplacements = new()
+    {
+        ['♪'] = "#",
+        ['♫'] = "#",
+    };
+
+    private readonly PluginRequest _request;
+    private readonly List<SrtBlock> _blocks;
+    private readonly Dictionary<string, string> _persistedReplacements;
+    private readonly ObservableCollection<UnicodeCharRow> _rows = new();
+
+    private TextBlock _summaryLabel = null!;
+    private TextBlock _subtitleLabel = null!;
+    private TextBlock _noCharsLabel = null!;
+    private Border _headerBorder = null!;
+    private Border _listBorder = null!;
+    private ListBox _charsList = null!;
+    private Button _applyButton = null!;
+    private Button _googleButton = null!;
+
+    public MainWindow() : this(new PluginRequest()) { }
+
+    public MainWindow(PluginRequest request)
+    {
+        _request = request;
+        InitializeComponent();
+
+        _blocks = SubRipParser.Parse(request.Subtitle.SubRip);
+        _persistedReplacements = LoadReplacementsFromSettings(request.Settings);
+
+        BuildRows();
+        _charsList.ItemsSource = _rows;
+        _charsList.SelectionChanged += (_, _) => UpdateGoogleButton();
+
+        var scope = request.SelectedIndices.Count > 0
+            ? $"the {request.SelectedIndices.Count} selected line(s)"
+            : "all lines";
+        _subtitleLabel.Text = $"Detected non-ANSI characters in {scope}. Edit the replacement for each character — leave blank to simply remove it.";
+
+        UpdateUiForRows();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+        _summaryLabel = this.FindControl<TextBlock>("SummaryLabel")!;
+        _subtitleLabel = this.FindControl<TextBlock>("SubtitleLabel")!;
+        _noCharsLabel = this.FindControl<TextBlock>("NoCharsLabel")!;
+        _headerBorder = this.FindControl<Border>("HeaderBorder")!;
+        _listBorder = this.FindControl<Border>("ListBorder")!;
+        _charsList = this.FindControl<ListBox>("CharsList")!;
+        _applyButton = this.FindControl<Button>("ApplyButton")!;
+        _googleButton = this.FindControl<Button>("GoogleButton")!;
+    }
+
+    protected override void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+        this.BringToForeground();
+    }
+
+    private void BuildRows()
+    {
+        var selected = new HashSet<int>(_request.SelectedIndices);
+        var applyToAll = selected.Count == 0;
+
+        var counts = new Dictionary<char, int>();
+        var lineSets = new Dictionary<char, SortedSet<int>>();
+
+        for (var i = 0; i < _blocks.Count; i++)
+        {
+            if (!applyToAll && !selected.Contains(i))
+            {
+                continue;
+            }
+
+            foreach (var c in _blocks[i].Text)
+            {
+                if (c <= 255)
+                {
+                    continue;
+                }
+
+                counts[c] = counts.TryGetValue(c, out var existing) ? existing + 1 : 1;
+                if (!lineSets.TryGetValue(c, out var lines))
+                {
+                    lines = new SortedSet<int>();
+                    lineSets[c] = lines;
+                }
+                lines.Add(i);
+            }
+        }
+
+        foreach (var c in counts.Keys.OrderBy(c => c))
+        {
+            var row = new UnicodeCharRow(c, counts[c], lineSets[c], ResolveDefaultReplacement(c));
+            row.PropertyChanged += OnRowChanged;
+            _rows.Add(row);
+        }
+    }
+
+    private string ResolveDefaultReplacement(char c)
+    {
+        var hex = ((int)c).ToString("X4");
+        if (_persistedReplacements.TryGetValue(hex, out var persisted))
+        {
+            return persisted;
+        }
+        return DefaultReplacements.TryGetValue(c, out var builtIn) ? builtIn : string.Empty;
+    }
+
+    private void UpdateUiForRows()
+    {
+        if (_rows.Count == 0)
+        {
+            _noCharsLabel.IsVisible = true;
+            _headerBorder.IsVisible = false;
+            _listBorder.IsVisible = false;
+            _applyButton.IsEnabled = false;
+            _summaryLabel.Text = string.Empty;
+        }
+        else
+        {
+            _noCharsLabel.IsVisible = false;
+            _headerBorder.IsVisible = true;
+            _listBorder.IsVisible = true;
+            UpdateSummary();
+        }
+
+        UpdateGoogleButton();
+    }
+
+    private void OnRowChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(UnicodeCharRow.Include))
+        {
+            UpdateSummary();
+        }
+    }
+
+    private void UpdateSummary()
+    {
+        var totalRows = _rows.Count;
+        var selectedRows = _rows.Count(r => r.Include);
+        var selectedOccurrences = _rows.Where(r => r.Include).Sum(r => r.Count);
+        _summaryLabel.Text = $"{selectedRows} of {totalRows} character(s) selected — {selectedOccurrences} occurrence(s) will be replaced.";
+        _applyButton.IsEnabled = selectedRows > 0;
+    }
+
+    private void UpdateGoogleButton()
+    {
+        _googleButton.IsEnabled = _charsList.SelectedItem is UnicodeCharRow;
+    }
+
+    private void OnSelectAll(object? sender, RoutedEventArgs e)
+    {
+        foreach (var row in _rows)
+        {
+            row.Include = true;
+        }
+    }
+
+    private void OnSelectNone(object? sender, RoutedEventArgs e)
+    {
+        foreach (var row in _rows)
+        {
+            row.Include = false;
+        }
+    }
+
+    private void OnGoogleSelected(object? sender, RoutedEventArgs e)
+    {
+        if (_charsList.SelectedItem is not UnicodeCharRow row)
+        {
+            return;
+        }
+
+        var url = "https://www.google.com/search?q=" + Uri.EscapeDataString(row.HexCode + " Unicode");
+        TryOpenUrl(url);
+    }
+
+    private static void TryOpenUrl(string url)
+    {
+        try
+        {
+            ProcessStartInfo psi;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                psi = new ProcessStartInfo("cmd", "/c start \"\" \"" + url + "\"") { CreateNoWindow = true };
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                psi = new ProcessStartInfo("open", url);
+            }
+            else
+            {
+                psi = new ProcessStartInfo("xdg-open", url);
+            }
+
+            Process.Start(psi);
+        }
+        catch
+        {
+            // Best-effort - if the platform has no browser, silently ignore.
+        }
+    }
+
+    private void OnCancel(object? sender, RoutedEventArgs e)
+    {
+        App.Response = new PluginResponse { Status = PluginStatus.Cancelled };
+        Close();
+    }
+
+    private void OnApply(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var activeRows = _rows.Where(r => r.Include).ToList();
+            if (activeRows.Count == 0)
+            {
+                App.Response = new PluginResponse { Status = PluginStatus.Cancelled };
+                Close();
+                return;
+            }
+
+            var lineIndices = new HashSet<int>();
+            var occurrences = 0;
+            foreach (var row in activeRows)
+            {
+                foreach (var lineIndex in row.LineIndices)
+                {
+                    lineIndices.Add(lineIndex);
+                }
+                occurrences += row.Count;
+            }
+
+            foreach (var lineIndex in lineIndices)
+            {
+                var sb = new StringBuilder(_blocks[lineIndex].Text.Length);
+                foreach (var c in _blocks[lineIndex].Text)
+                {
+                    var matched = false;
+                    foreach (var row in activeRows)
+                    {
+                        if (row.Character == c)
+                        {
+                            sb.Append(row.Replacement);
+                            matched = true;
+                            break;
+                        }
+                    }
+                    if (!matched)
+                    {
+                        sb.Append(c);
+                    }
+                }
+                _blocks[lineIndex].Text = sb.ToString();
+            }
+
+            App.Response = new PluginResponse
+            {
+                Status = PluginStatus.Ok,
+                Message = $"Replaced {occurrences} Unicode character occurrence(s) across {lineIndices.Count} line(s).",
+                UndoDescription = "Remove Unicode characters",
+                Subtitle = new PluginSubtitle
+                {
+                    Format = "SubRip",
+                    Native = SubRipParser.Serialize(_blocks),
+                },
+                Settings = BuildSettings(),
+            };
+        }
+        catch (Exception ex)
+        {
+            App.Response = new PluginResponse { Status = PluginStatus.Error, Message = ex.Message };
+        }
+
+        Close();
+    }
+
+    private JsonElement BuildSettings()
+    {
+        var merged = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var kvp in _persistedReplacements)
+        {
+            merged[kvp.Key] = kvp.Value;
+        }
+
+        foreach (var row in _rows)
+        {
+            var hex = ((int)row.Character).ToString("X4");
+            merged[hex] = row.Replacement ?? string.Empty;
+        }
+
+        var payload = new { replacements = merged };
+        var json = JsonSerializer.Serialize(payload);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    private static Dictionary<string, string> LoadReplacementsFromSettings(JsonElement? settings)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (settings is null || settings.Value.ValueKind != JsonValueKind.Object)
+        {
+            return result;
+        }
+
+        if (!settings.Value.TryGetProperty("replacements", out var replacements)
+            || replacements.ValueKind != JsonValueKind.Object)
+        {
+            return result;
+        }
+
+        foreach (var property in replacements.EnumerateObject())
+        {
+            if (property.Value.ValueKind == JsonValueKind.String)
+            {
+                result[property.Name] = property.Value.GetString() ?? string.Empty;
+            }
+        }
+
+        return result;
+    }
+}

--- a/se5/RemoveUnicodeCharacters/Program.cs
+++ b/se5/RemoveUnicodeCharacters/Program.cs
@@ -1,0 +1,10 @@
+using SubtitleEdit.Plugins.Shared;
+using System;
+
+namespace SubtitleEdit.Plugins.RemoveUnicodeCharacters;
+
+public static class Program
+{
+    [STAThread]
+    public static int Main(string[] args) => PluginBootstrap.Run<App>(args);
+}

--- a/se5/RemoveUnicodeCharacters/README.md
+++ b/se5/RemoveUnicodeCharacters/README.md
@@ -1,0 +1,36 @@
+# Remove Unicode characters (Subtitle Edit 5 plugin)
+
+Detects non-ANSI characters (code point above 255) in the subtitle and lets you
+remove or replace each one. Modeled after the original SE4 plugin
+[`RemoveUnicodeCharacters`](../../source/RemoveUnicodeCharacters/) but rebuilt
+on Avalonia and the shared [`Plugin-Shared`](../Plugin-Shared/) library.
+
+## UI
+
+A preview window with one row per unique character:
+
+- **Checkbox** — include this character in the apply step.
+- **Code** — Unicode hex (e.g. `U+266A`).
+- **Char** — the glyph itself.
+- **Count** — total occurrences in the (selected) lines.
+- **Replace with** — editable text used as the replacement. Leave blank to
+  simply remove the character.
+- **Lines** — comma-separated list of 1-based line numbers where the character
+  occurs.
+
+Defaults: `♪` and `♫` map to `#`; everything else is blank (= remove). Custom
+replacements are persisted via the SE5 plugin Settings round-trip so they
+reappear on the next run.
+
+Toolbar buttons:
+
+- *Select all* / *Select none* toggle every row.
+- *Google selected* opens a search for the selected row's hex code.
+- *Cancel* exits without changes.
+- *Apply* (accent) replaces every checked character with its replacement,
+  reports the count to the SE status bar, and registers a "Remove Unicode
+  characters" undo entry.
+
+## Build
+
+See `.github/workflows/remove-unicode-characters.yml`.

--- a/se5/RemoveUnicodeCharacters/RemoveUnicodeCharacters.csproj
+++ b/se5/RemoveUnicodeCharacters/RemoveUnicodeCharacters.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>RemoveUnicodeCharacters</AssemblyName>
+    <RootNamespace>SubtitleEdit.Plugins.RemoveUnicodeCharacters</RootNamespace>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Plugin-Shared\Plugin-Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/se5/RemoveUnicodeCharacters/UnicodeCharRow.cs
+++ b/se5/RemoveUnicodeCharacters/UnicodeCharRow.cs
@@ -1,0 +1,38 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SubtitleEdit.Plugins.RemoveUnicodeCharacters;
+
+public partial class UnicodeCharRow : ObservableObject
+{
+    [ObservableProperty] private bool _include = true;
+    [ObservableProperty] private string _replacement = string.Empty;
+
+    public char Character { get; }
+
+    /// <summary>Unicode hex code as a four-digit "U+XXXX" string.</summary>
+    public string HexCode { get; }
+
+    /// <summary>The character itself, rendered as a glyph.</summary>
+    public string Glyph { get; }
+
+    /// <summary>1-based line numbers where the character occurs, joined by ", ".</summary>
+    public string LinesText { get; }
+
+    /// <summary>Total number of occurrences across all lines.</summary>
+    public int Count { get; }
+
+    public IReadOnlyList<int> LineIndices { get; }
+
+    public UnicodeCharRow(char character, int count, IEnumerable<int> lineIndices, string replacement)
+    {
+        Character = character;
+        HexCode = "U+" + ((int)character).ToString("X4");
+        Glyph = character.ToString();
+        Count = count;
+        LineIndices = lineIndices.OrderBy(i => i).ToArray();
+        LinesText = string.Join(", ", LineIndices.Select(i => (i + 1).ToString()));
+        _replacement = replacement;
+    }
+}

--- a/se5/RemoveUnicodeCharacters/app.manifest
+++ b/se5/RemoveUnicodeCharacters/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="SubtitleEdit.Plugins.RemoveUnicodeCharacters" />
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/se5/RemoveUnicodeCharacters/plugin.json
+++ b/se5/RemoveUnicodeCharacters/plugin.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": 1,
+  "name": "Remove Unicode characters",
+  "description": "Detects non-ANSI characters in the subtitle and lets you remove or replace each one. Shows a checkable preview with the count and line numbers per character.",
+  "version": "1.0.0",
+  "author": "Subtitle Edit",
+  "url": "https://github.com/SubtitleEdit/plugins/tree/main/se5/RemoveUnicodeCharacters",
+  "menu": "Tools",
+  "minSeVersion": "5.0.0",
+  "runtime": "dotnet",
+  "entry": "RemoveUnicodeCharacters.dll"
+}


### PR DESCRIPTION
## Summary
- Adds a new SE5 plugin that detects non-ANSI characters (code point > 255) and lets the user remove or replace each one through a checkable preview window with an inline editable "Replace with" textbox per row.
- Replacements are persisted across runs via the SE5 plugin Settings round-trip; built-in defaults map ♪/♫ to `#` and everything else to empty (= remove).
- Adds the matching multi-rid build workflow (mirrors `word-censor.yml`) and the catalog entry in `se5-plugins.json`.

## UI
- One row per unique character: checkbox, hex code (`U+XXXX`), glyph, count, editable replacement, line numbers.
- Toolbar: *Select all*, *Select none*, *Google selected* (opens a hex-code search in the system browser).
- Apply replaces in a single pass per affected line, reports `Replaced N occurrence(s) across M line(s)` to SE's status bar, and registers a "Remove Unicode characters" undo entry.

## Test plan
- [ ] CI build passes for all six RIDs (win/linux/osx × x64/arm64).
- [ ] Manually run on an SRT with `♪`, `♫`, `…`, and accented letters — selected lines only.
- [ ] Edit a replacement, Apply, re-run — confirm the edited value is restored from settings.
- [ ] Verify the entry appears in SE's *Get plugins* dialog after a release tag is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)