### PR TITLE
RemoveUnicodeCharacters: expand built-in replacement defaults

### DIFF
--- a/se5/RemoveUnicodeCharacters/MainWindow.axaml.cs
+++ b/se5/RemoveUnicodeCharacters/MainWindow.axaml.cs
@@ -16,13 +16,6 @@ namespace SubtitleEdit.Plugins.RemoveUnicodeCharacters;
 
 public partial class MainWindow : Window
 {
-    /// <summary>Built-in default replacements (used when the user has no persisted setting for a character).</summary>
-    private static readonly Dictionary<char, string> DefaultReplacements = new()
-    {
-        ['♪'] = "#",
-        ['♫'] = "#",
-    };
-
     private readonly PluginRequest _request;
     private readonly List<SrtBlock> _blocks;
     private readonly Dictionary<string, string> _persistedReplacements;
@@ -125,7 +118,7 @@ public partial class MainWindow : Window
         {
             return persisted;
         }
-        return DefaultReplacements.TryGetValue(c, out var builtIn) ? builtIn : string.Empty;
+        return UnicodeDefaults.Map.TryGetValue(c, out var builtIn) ? builtIn : string.Empty;
     }
 
     private void UpdateUiForRows()

--- a/se5/RemoveUnicodeCharacters/UnicodeDefaults.cs
+++ b/se5/RemoveUnicodeCharacters/UnicodeDefaults.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+
+namespace SubtitleEdit.Plugins.RemoveUnicodeCharacters;
+
+/// <summary>
+/// Built-in suggested replacements for non-ANSI characters that have a near-lossless
+/// or universally understood ASCII equivalent. Used as the seed value for the
+/// "Replace with" column when the user has no persisted setting for a character.
+/// Debatable cases (bullets, arrows, math, trademark, music accidentals) are
+/// deliberately omitted - the UI shows them blank so the user picks per row.
+/// </summary>
+internal static class UnicodeDefaults
+{
+    public static readonly Dictionary<char, string> Map = new()
+    {
+        // Smart quotes -> straight ASCII quotes
+        ['‘'] = "'",   // ' left single quotation mark
+        ['’'] = "'",   // ' right single quotation mark
+        ['‚'] = ",",   // ‚ single low-9 quotation mark
+        ['‛'] = "'",   // ‛ single high-reversed-9
+        ['“'] = "\"",  // " left double quotation mark
+        ['”'] = "\"",  // " right double quotation mark
+        ['„'] = "\"",  // „ double low-9 quotation mark
+        ['‟'] = "\"",  // ‟ double high-reversed-9
+
+        // Hyphens / dashes -> hyphen-minus
+        ['‐'] = "-",   // ‐ hyphen
+        ['‑'] = "-",   // ‑ non-breaking hyphen
+        ['‒'] = "-",   // ‒ figure dash
+        ['–'] = "-",   // – en dash
+        ['—'] = "-",   // — em dash
+        ['―'] = "-",   // ― horizontal bar
+        ['−'] = "-",   // − minus sign
+
+        // Ellipses / dot leaders
+        ['․'] = ".",   // ․ one-dot leader
+        ['‥'] = "..",  // ‥ two-dot leader
+        ['…'] = "...", // … horizontal ellipsis
+
+        // Music notes (note heads, not accidentals)
+        ['♩'] = "#",   // ♩ quarter note
+        ['♪'] = "#",   // ♪ eighth note
+        ['♫'] = "#",   // ♫ beamed eighth notes
+        ['♬'] = "#",   // ♬ beamed sixteenth notes
+
+        // Wide / narrow space variants -> regular space
+        [' '] = " ",   // en quad
+        [' '] = " ",   // em quad
+        [' '] = " ",   // en space
+        [' '] = " ",   // em space
+        [' '] = " ",   // three-per-em space
+        [' '] = " ",   // four-per-em space
+        [' '] = " ",   // six-per-em space
+        [' '] = " ",   // figure space
+        [' '] = " ",   // punctuation space
+        [' '] = " ",   // thin space
+        [' '] = " ",   // hair space
+        [' '] = " ",   // narrow no-break space
+        [' '] = " ",   // medium mathematical space
+        ['　'] = " ",   // ideographic space
+
+        // Zero-width and joiner controls -> remove
+        ['​'] = "",    // zero-width space
+        ['‌'] = "",    // zero-width non-joiner
+        ['‍'] = "",    // zero-width joiner
+        ['⁠'] = "",    // word joiner
+        ['﻿'] = "",    // zero-width no-break space / BOM
+    };
+}


### PR DESCRIPTION
## Summary
- Grow the built-in replacement defaults for the `RemoveUnicodeCharacters` plugin from 2 entries (`♪`/`♫` → `#`) to 41.
- Extract the dictionary into its own `UnicodeDefaults.cs` so `MainWindow.axaml.cs` stays focused on UI/apply logic.
- Behavior unchanged for any character the user has already persisted a replacement for — the persisted value still wins. The new defaults only seed the "Replace with" textbox for characters with no setting yet.

## Categories added

| Group | Count | Mapping |
| --- | --- | --- |
| Smart double quotes (`“ ” „ ‟`) | 4 | `"` |
| Smart single quotes (`‘ ’ ‛`) + low-9 (`‚`) | 4 | `'` / `,` |
| Dashes (`‐ ‑ ‒ – — ― −`) | 7 | `-` |
| Ellipsis variants (`․ ‥ …`) | 3 | `.` / `..` / `...` |
| Music note heads (`♩ ♪ ♫ ♬`) | 4 | `#` |
| Wide/narrow space variants | 14 | ` ` |
| Zero-width / joiners / BOM | 5 | `` (removed) |

Deliberately *not* defaulted (debatable, left blank so the user picks per row): bullets `• ‣`, arrows `→ ← ↑ ↓`, math `≤ ≥ ≠`, trademarks `™ ℗ ℠`, music accidentals `♭ ♮ ♯`.

## Test plan
- [ ] CI build passes for all six RIDs.
- [ ] Run on an SRT containing smart quotes, em dashes, ellipses, NBSP — confirm the proposed replacement is pre-filled for each.
- [ ] Run again — confirm previously persisted user edits still override the new defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)