### PR TITLE
Add AI Translate (OpenSubtitles) plugin

### DIFF
--- a/se5-plugins.json
+++ b/se5-plugins.json
@@ -101,6 +101,21 @@
         "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-remove-unicode-characters-v1.1/RemoveUnicodeCharacters-osx-x64.zip",
         "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-remove-unicode-characters-v1.1/RemoveUnicodeCharacters-osx-arm64.zip"
       }
+    },
+    {
+      "name": "AI Translate (OpenSubtitles)",
+      "description": "Translate subtitles using the AI OpenSubtitles translation API. Supports auto-detection, multiple engines, and language selection.",
+      "version": "0.2.2",
+      "author": "AI OpenSubtitles",
+      "url": "https://github.com/iceman1010/se5-ai-translator",
+      "date": "2026-06-10",
+      "minSeVersion": "5.0.0",
+      "downloads": {
+        "win-x64":     "https://github.com/iceman1010/se5-ai-translator/releases/download/v0.2.2/se-ai-translator-windows-x86_64.zip",
+        "linux-x64":   "https://github.com/iceman1010/se5-ai-translator/releases/download/v0.2.2/se-ai-translator-linux-x86_64.tar.gz",
+        "osx-x64":     "https://github.com/iceman1010/se5-ai-translator/releases/download/v0.2.2/se-ai-translator-macos-x86_64.tar.gz",
+        "osx-arm64":   "https://github.com/iceman1010/se5-ai-translator/releases/download/v0.2.2/se-ai-translator-macos-aarch64.tar.gz"
+      }
     }
   ]
 }

--- a/se5/AITranslateOpenSubtitles/README.md
+++ b/se5/AITranslateOpenSubtitles/README.md
@@ -1,0 +1,27 @@
+# AI Translate (OpenSubtitles) Plugin
+
+SubtitleEdit 5 plugin for translating subtitles via the AI OpenSubtitles API.
+
+## Features
+
+- Translate subtitles to 100+ languages via AI
+- Automatic source language detection
+- Multiple AI translation engines to choose from
+- Translation runs in the background — UI stays responsive
+- Built-in self-update mechanism
+- Cross-platform: Windows, macOS, Linux
+
+## Installation
+
+Download from SubtitleEdit 5: **Plugins → Manage plugins... → Get plugins online...**
+
+## Project
+
+- **Repository:** https://github.com/iceman1010/se5-ai-translator
+- **License:** MIT
+- **Author:** AI OpenSubtitles
+
+## Requirements
+
+- SubtitleEdit 5.0.0 or later
+- OpenSubtitles account with API credits (purchase at https://ai.opensubtitles.com/credits)

--- a/se5/AITranslateOpenSubtitles/generate-downloads.sh
+++ b/se5/AITranslateOpenSubtitles/generate-downloads.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Helper script to generate release download URLs for se5-plugins.json
+# Usage: ./generate-downloads.sh v1.0.0
+
+VERSION="${1:-v0.2.2}"
+REPO="iceman1010/se5-ai-translator"
+BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+cat << EOF
+"downloads": {
+  "win-x64":     "${BASE_URL}/se-ai-translator-windows-x86_64.zip",
+  "win-arm64":   "${BASE_URL}/se-ai-translator-windows-arm64.zip",
+  "linux-x64":   "${BASE_URL}/se-ai-translator-linux-x86_64.tar.gz",
+  "linux-arm64": "${BASE_URL}/se-ai-translator-linux-x86_64.tar.gz",
+  "osx-x64":     "${BASE_URL}/se-ai-translator-macos-x86_64.tar.gz",
+  "osx-arm64":   "${BASE_URL}/se-ai-translator-macos-aarch64.tar.gz"
+}
+EOF

--- a/se5/AITranslateOpenSubtitles/plugin.json
+++ b/se5/AITranslateOpenSubtitles/plugin.json
@@ -1,0 +1,17 @@
+{
+  "apiVersion": 1,
+  "name": "AI Translate (OpenSubtitles)",
+  "description": "Translate subtitles using the AI OpenSubtitles translation API. Supports auto-detection, multiple engines, and language selection.",
+  "version": "0.1.0",
+  "author": "AI OpenSubtitles",
+  "url": "https://ai.opensubtitles.com",
+  "menu": "Translate",
+  "shortcut": "Control+Shift+T",
+  "minSeVersion": "5.0.0",
+  "icon": "icon.png",
+  "executables": {
+    "windows": "se-ai-translator.exe",
+    "linux": "se-ai-translator",
+    "macos": "se-ai-translator"
+  }
+}


### PR DESCRIPTION
## Add AI Translate (OpenSubtitles) plugin

A SubtitleEdit 5 plugin that translates subtitles using the AI OpenSubtitles translation API. Supports automatic language detection, multiple AI engines, and over 100 languages.

**Repository:** https://github.com/iceman1010/se5-ai-translator
**Author:** AI OpenSubtitles
**License:** MIT

### Supported platforms
- Windows x64
- Linux x64
- macOS x64
- macOS ARM64

### Release workflow
The plugin is built via GitHub Actions on every push to master. New versions are published automatically to https://github.com/iceman1010/se5-ai-translator/releases.