### PR TITLE
Point se5-plugins.json at British/American English v1.3 releases

### DIFF
--- a/se5-plugins.json
+++ b/se5-plugins.json
@@ -20,35 +20,35 @@
     {
       "name": "British to American",
       "description": "Converts British English spellings to American English in the subtitle. Shows a checkable preview of every proposed change.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": "Subtitle Edit",
       "url": "https://github.com/SubtitleEdit/plugins/tree/main/se5/BritishToAmerican",
-      "date": "2026-08-14",
+      "date": "2026-09-01",
       "minSeVersion": "5.0.0",
       "downloads": {
-        "win-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.2/BritishToAmerican-win-x64.zip",
-        "win-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.2/BritishToAmerican-win-arm64.zip",
-        "linux-x64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.2/BritishToAmerican-linux-x64.zip",
-        "linux-arm64": "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.2/BritishToAmerican-linux-arm64.zip",
-        "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.2/BritishToAmerican-osx-x64.zip",
-        "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.2/BritishToAmerican-osx-arm64.zip"
+        "win-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.3/BritishToAmerican-win-x64.zip",
+        "win-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.3/BritishToAmerican-win-arm64.zip",
+        "linux-x64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.3/BritishToAmerican-linux-x64.zip",
+        "linux-arm64": "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.3/BritishToAmerican-linux-arm64.zip",
+        "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.3/BritishToAmerican-osx-x64.zip",
+        "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-british-to-american-v1.3/BritishToAmerican-osx-arm64.zip"
       }
     },
     {
       "name": "American to British",
       "description": "Converts American English spellings to British English in the subtitle. Shows a checkable preview of every proposed change.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": "Subtitle Edit",
       "url": "https://github.com/SubtitleEdit/plugins/tree/main/se5/AmericanToBritish",
-      "date": "2026-08-14",
+      "date": "2026-09-01",
       "minSeVersion": "5.0.0",
       "downloads": {
-        "win-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.2/AmericanToBritish-win-x64.zip",
-        "win-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.2/AmericanToBritish-win-arm64.zip",
-        "linux-x64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.2/AmericanToBritish-linux-x64.zip",
-        "linux-arm64": "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.2/AmericanToBritish-linux-arm64.zip",
-        "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.2/AmericanToBritish-osx-x64.zip",
-        "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.2/AmericanToBritish-osx-arm64.zip"
+        "win-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.3/AmericanToBritish-win-x64.zip",
+        "win-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.3/AmericanToBritish-win-arm64.zip",
+        "linux-x64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.3/AmericanToBritish-linux-x64.zip",
+        "linux-arm64": "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.3/AmericanToBritish-linux-arm64.zip",
+        "osx-x64":     "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.3/AmericanToBritish-osx-x64.zip",
+        "osx-arm64":   "https://github.com/SubtitleEdit/plugins/releases/download/se5-american-to-british-v1.3/AmericanToBritish-osx-arm64.zip"
       }
     },
     {


### PR DESCRIPTION
Version/date/download-URL bump for the v1.3 releases of both English-variant plugins (direction-gated word list, PR #287, fixes SubtitleEdit/subtitleedit#14374). Both release tags verified to have all 6 platform zips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)